### PR TITLE
defined log variable in __init__ which is used later on

### DIFF
--- a/salesforce/__init__.py
+++ b/salesforce/__init__.py
@@ -10,8 +10,10 @@ A database backend for the Django ORM.
 
 Allows access to all Salesforce objects accessible via the SOQL API.
 """
-
+import logging
 import httplib2, ssl
+
+log = logging.getLogger(__name__)
 
 def ssl_wrap_socket(sock, key_file, cert_file, disable_validation, ca_certs):
 	if disable_validation:


### PR DESCRIPTION
the `log` variable is used a little further down if an `SSLError` occurs
