### PR TITLE
Fix test failures where assumed data does not exist

### DIFF
--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -285,8 +285,10 @@ class BasicSOQLTest(TestCase):
 		"""
 		Verify that a field with milisecond resolution is readable.
 		"""
-		account = Account.objects.all()[0]
-		self.assertTrue(isinstance(account.LastModifiedDate, datetime.datetime))
+		triggers = CronTrigger.objects.all()
+		if not triggers:
+			self.skipTest("No object with milisecond resolution found.")
+		self.assertTrue(isinstance(triggers[0].PreviousFireTime, datetime.datetime))
 		# The reliability of this is only 99.9%, therefore it is commented out.
 		#self.assertNotEqual(trigger.PreviousFireTime.microsecond, 0)
 


### PR DESCRIPTION
When adding test coverage for another branch, I ran into failures with the test_foreign_key and test_datetime_miliseconds test methods.

I've updated each of these methods to improve the likelihood that the data required by each assertion exists.  An org may not always have a CronTrigger that has a PreviousFireTime set, or an org may have a contact owned by a user other than the user used by django-salesforce.
