### PR TITLE
Refactor test_escape_single_quote_in_raw_query to support Python 2.6.

### DIFF
--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -393,7 +393,7 @@ class BasicSOQLTest(TestCase):
 		manually_escaped = '''Dr. Evil\\'s Giant "Laser", LLC'''
 		try:
 			retrieved_account = Account.objects.raw(
-				"SELECT Id, Name FROM Account WHERE Name = '{}'".format(manually_escaped))[0]
+				"SELECT Id, Name FROM Account WHERE Name = '%s'" % manually_escaped)[0]
 			self.assertEqual(account_name, retrieved_account.Name)
 		finally:
 			account.delete()


### PR DESCRIPTION
As spotted by [@hynecker](https://github.com/hynekcer), in  f02892bfde843ca389f4992fa9179ee614f032b4 I broke compatibility with Python 2.6 while running the test suite.  Rewrote the offending line.
