### PR TITLE
Fixed bug with long queries that remained after replaced restkit to requests

### DIFF
--- a/salesforce/backend/query.py
+++ b/salesforce/backend/query.py
@@ -394,15 +394,10 @@ class CursorWrapper(object):
 
 			if results['done']:
 				break
-
+			# see about Retrieving the Remaining SOQL Query Results
 			# http://www.salesforce.com/us/developer/docs/api_rest/Content/dome_query.htm#heading_2_1
 			response = self.query_more(results['nextRecordsUrl'])
-			jsrc = force_text(response.body_string()).encode(settings.DEFAULT_CHARSET)
-
-			if(jsrc):
-				results = json.loads(jsrc)
-			else:
-				break
+			results = response.json(parse_float=decimal.Decimal)
 		return output
 
 	def __iter__(self):


### PR DESCRIPTION
This bug could be found only for query results longer than ~~200~~ 1000 records for me.
