### PR TITLE
Fixed Meta class in example.models according to fixed README. closed #2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,11 @@ Quick Start
 7. Define a model that extends ``salesforce.models.SalesforceModel``
    or export the complete SF schema by
    ``python manage.py inspectdb --database=salesforce`` and simplify it
-   to what you need.
+   to what you need. If an inner ``Meta`` class is used, e.g. for a
+   ``db_table`` option of custom SF object with a name that ends with ``__c``,
+   then that Meta must be a descendant of ``SalesforceModel.Meta`` or must have
+   the attribute ``managed=False``.
+
 8. If you want to use the model in the Django admin interface, use a
    ModelAdmin that extends ``salesforce.admin.RoutedModelAdmin``
 9. You're all done! Just use your model like a normal Django model.

--- a/salesforce/testrunner/example/models.py
+++ b/salesforce/testrunner/example/models.py
@@ -321,7 +321,7 @@ class BusinessHours(SalesforceModel):
 	# ... much more fields, but we use only this one TimeFiled for test
 	MondayStartTime = models.TimeField()
 
-	class Meta:
+	class Meta(SalesforceModel.Meta):
 		verbose_name_plural = "BusinessHours"
 
 
@@ -337,7 +337,7 @@ class GeneralCustomModel(SalesforceModel):
  		TEST_CUSTOM_FIELD = 'TIMBASURVEYS__SurveyQuestion__c.TIMBASURVEYS__Question__c'
  	Other fields shouldn't be required for saving that object.
  	"""
-	# The line "managed = False" or Meta inherited from SalesforceMoled.Meta
+	# The line "managed = False" or Meta inherited from SalesforceModel.Meta
 	# is especially important if the model shares a table with other model.
  	class Meta:
  		db_table = test_custom_db_table


### PR DESCRIPTION
Fixed bug: the command `python manage.py syncdb --database=default` caused  
`Creating table BusinessHours` in the default db.

This is my last commit for v0.3. Do you want to pull it with  freelancersunion/generic-foreign-key-support to master?
