### PR TITLE
Fixed to run with Django 1.7 RC 1

### DIFF
--- a/salesforce/backend/creation.py
+++ b/salesforce/backend/creation.py
@@ -14,7 +14,7 @@ import sys
 from django.db.backends.creation import BaseDatabaseCreation
 
 class DatabaseCreation(BaseDatabaseCreation):
-	def create_test_db(self, verbosity=1, autoclobber=False):
+	def create_test_db(self, verbosity=1, autoclobber=False, serialize=True):
 		test_database_name = self._get_test_db_name()
 		
 		if verbosity >= 1:


### PR DESCRIPTION
On Thuesday has been released Django 1.7 RC 1. It caused exception on start with django-salesforce due to new code for test database serialization in Django 1.7 RC 1.

Serialization is ignored as well as migrations etc.
