### PR TITLE
Allow to select individual fields of related object

### DIFF
--- a/salesforce/backend/query.py
+++ b/salesforce/backend/query.py
@@ -174,7 +174,9 @@ def prep_for_deserialize(model, record, using, init_list=None):
 				fields[x.name] = record[simple_column]['Type']
 			else:
 				# Normal fields
-				field_val = record[x.column]
+				field_val = record
+				for col in x.column.split('.'):
+					field_val = field_val[col]
 				#db_type = x.db_type(connection=connections[using])
 				if(x.__class__.__name__ == 'DateTimeField' and field_val is not None):
 					d = datetime.datetime.strptime(field_val, SALESFORCE_DATETIME_FORMAT)


### PR DESCRIPTION
This PR allows simple querying (retrieving and filtering) on related objects by mapping just some fields as normal fields on the parent model.

Consider the following model, with a custom relationship with `Opportunity`

``` python
class SupplierOpportunity(models.Model):
    name = models.CharField(max_length=120, db_column='Name')
    # ... other fields ...
    stage_name = models.CharField(max_length=150, db_column='Opportunity__r.StageName')

    class Meta:
        db_table = 'Opportunity_Supplier__c'

```

It is now possible to query this model and access the related attributes as its own fields:

``` python
# Filtering
obj_in_stage = SupplierOpportunity.objects.filter(stage_name='...')

# Accessing
stage_name = SupplierOpportunity.objects.get(pk='...').stage_name
```

P.S.: I am a total n00b with salesforce, but just happened to solve a filtering performance issue this way. If there are better ways to implement this, please don't hesitate to point it out.
