### PR TITLE
Integration of convertLead() from the SOAP API using beatbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ coverage_html
 log
 tests/inspectdb/models.py
 salesforce/packages/
+venv

--- a/README.rst
+++ b/README.rst
@@ -231,18 +231,18 @@ Advanced usage
      lead = Lead.objects.all()[0]
      response = convert_lead(lead)
 
-    For the particular case of ``Lead`` conversion, beware that having
-    some *custom* and *required* fields in either ``Contact``,
-    ``Account`` or ``Opportunity`` is not supported. This arises from
-    the fact that the conversion mechanism on the Salesforce side is only
-    meant to deal with standard Salesforce fields, so it does not really
-    care about populating custom fields at insert time.
+   For the particular case of ``Lead`` conversion, beware that having
+   some *custom* and *required* fields in either ``Contact``,
+   ``Account`` or ``Opportunity`` is not supported. This arises from
+   the fact that the conversion mechanism on the Salesforce side is only
+   meant to deal with standard Salesforce fields, so it does not really
+   care about populating custom fields at insert time.
 
-    One workaround is to map a custom required field in
-    your `Lead` object to every custom required field in the target
-    objects (i.e., `Contact`, `Opportunity` or `Account`). Follow the
-    `instructions<http://www.python.org/https://help.salesforce.com/apex/HTViewHelpDoc?id=customize_mapleads.htm>`_
-    for more details.
+   One workaround is to map a custom required field in
+   your `Lead` object to every custom required field in the target
+   objects (i.e., `Contact`, `Opportunity` or `Account`). Follow the
+   `instructions <http://www.python.org/https://help.salesforce.com/apex/HTViewHelpDoc?id=customize_mapleads.htm>`__
+   for more details.
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -216,6 +216,35 @@ Advanced usage
    name ``Contact`` and all tables that are prefixed with ``Account``. This
    filter works with all supported database types.
 
+-  **Accessing the Salesforce SOAP API** - There are some Salesforce actions that cannot or can hardly
+   be implemented using the generic relational database abstraction and the REST API.
+   For some of these actions there is an available endpoint in the old Salesforce API
+   (SOAP) that can be accessed using our utility module. In order to use that module,
+   you will need to install an additional dependency ::
+
+     pip install beatbox
+
+   Here is an example of usage with ``Lead`` conversion ::
+
+     from salesforce.utils import convert_lead
+
+     lead = Lead.objects.all()[0]
+     response = convert_lead(lead)
+
+    For the particular case of ``Lead`` conversion, beware that having
+    some *custom* and *required* fields in either ``Contact``,
+    ``Account`` or ``Opportunity`` is not supported. This arises from
+    the fact that the conversion mechanism on the Salesforce side is only
+    meant to deal with standard Salesforce fields, so it does not really
+    care about populating custom fields at insert time.
+
+    One workaround is to map a custom required field in
+    your `Lead` object to every custom required field in the target
+    objects (i.e., `Contact`, `Opportunity` or `Account`). Follow the
+    `instructions<http://www.python.org/https://help.salesforce.com/apex/HTViewHelpDoc?id=customize_mapleads.htm>`_
+    for more details.
+
+
 
 Caveats
 -------

--- a/README.rst
+++ b/README.rst
@@ -238,12 +238,6 @@ Advanced usage
    meant to deal with standard Salesforce fields, so it does not really
    care about populating custom fields at insert time.
 
-   One workaround is to map a custom required field in
-   your `Lead` object to every custom required field in the target
-   objects (i.e., `Contact`, `Opportunity` or `Account`). Follow the
-   `instructions <http://www.python.org/https://help.salesforce.com/apex/HTViewHelpDoc?id=customize_mapleads.htm>`__
-   for more details.
-
 
 
 Caveats

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ django>=1.4.2
 simplejson>=2.5.0
 pytz>=2012c
 requests>=2.0.0
+beatbox>=32.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ django>=1.4.2
 simplejson>=2.5.0
 pytz>=2012c
 requests>=2.0.0
-beatbox>=32.1

--- a/salesforce/tests/__init__.py
+++ b/salesforce/tests/__init__.py
@@ -2,3 +2,4 @@ from salesforce.tests.test_auth import *
 from salesforce.tests.test_integration import *
 from salesforce.tests.test_browser import *
 from salesforce.tests.test_unit import *
+from salesforce.tests.test_utils import *

--- a/salesforce/tests/test_utils.py
+++ b/salesforce/tests/test_utils.py
@@ -1,0 +1,17 @@
+from django.test import TestCase
+
+from salesforce.testrunner.example.models import Lead
+from salesforce.utils import convert_lead
+
+
+class UtilitiesTest(TestCase):
+
+    def test_lead_conversion(self):
+        """
+        Create a Lead object within Salesforce and try to
+        convert it.
+        """
+        lead = Lead(FirstName="Foo", LastName="Bar", Company="django-salesforce")
+        lead.save()
+        r = convert_lead(lead)
+        print("Response from convertLead: " + str(r))

--- a/salesforce/tests/test_utils.py
+++ b/salesforce/tests/test_utils.py
@@ -1,17 +1,37 @@
 from django.test import TestCase
+from django.core.exceptions import ObjectDoesNotExist
+import unittest
 
-from salesforce.testrunner.example.models import Lead
+
+from salesforce.testrunner.example.models import Account, Contact, Lead, Opportunity
 from salesforce.utils import convert_lead
+
+try:
+    import beatbox
+except ImportError:
+    beatbox = None
 
 
 class UtilitiesTest(TestCase):
 
+    @unittest.skipUnless(beatbox, "Beatbox needs to be installed in order to run this test.")
     def test_lead_conversion(self):
         """
         Create a Lead object within Salesforce and try to
-        convert it.
+        convert it, then clean all the generated objects.
         """
         lead = Lead(FirstName="Foo", LastName="Bar", Company="django-salesforce")
         lead.save()
         r = convert_lead(lead)
         print("Response from convertLead: " + str(r))
+        print("Account ID: " + str(r[0]))
+        print("Contact ID: " + str(r[1]))
+        print("Opportunity ID: " + str(r[3]))
+
+        # Cleaning up...
+        # Deleting the Account object will also delete the related Contact
+        # and Opportunity objects.
+        account = Account.objects.get(pk=str(r[0]))
+        account.delete()
+        
+        lead.delete()   # FYI, r[2] == lead.pk

--- a/salesforce/utils.py
+++ b/salesforce/utils.py
@@ -33,15 +33,6 @@ def convert_lead(lead, converted_status="Qualified - converted"):
     required fields. This arises from the fact that `convertLead()`
     is only meant to deal with standard Salesforce fields, so it does
     not really care about populating custom fields at insert time.
-
-    One workaround is to map a custom required field in
-    your `Lead` object to every custom required field in the target
-    objects (i.e., `Contact`, `Opportunity` or `Account`). Follow the
-    instructions at
-
-    https://help.salesforce.com/apex/HTViewHelpDoc?id=customize_mapleads.htm
-
-    for more details.
     """
     if not beatbox:
         raise RuntimeError("To use convert_lead, you'll need to install the Beatbox library.")

--- a/salesforce/utils.py
+++ b/salesforce/utils.py
@@ -1,0 +1,50 @@
+# django-salesforce
+
+"""
+A set of tools to deal with Salesforce actions that
+cannot or can hardly be implemented using the generic
+relational database abstraction.
+
+The Salesforce REST API is missing a few endpoints that
+are available in the SOAP API. We are using `beatbox` as
+a workaround for those specific actions (such as Lead-Contact
+conversion).
+"""
+
+from django.conf import settings
+
+import beatbox
+
+
+def convert_lead(lead, converted_status="Qualified - converted"):
+    """
+    Convert `lead` using the `convertLead()` endpoint exposed
+    by the SOAP API.
+
+    The parameter `lead` is expected to be a Lead object that
+    has not been converted yet.
+
+    TODO:
+    The current implementation won't work in case your `Contact`,
+    `Account` or `Opportunity` objects have some custom **and**
+    required fields. This arises from the fact that `convertLead()`
+    is only meant to deal with standard Salesforce fields, so it does
+    not really care about populating custom fields at insert time.
+    """
+    soap_client = beatbox.PythonClient()
+    settings_dict = settings.DATABASES['salesforce']
+
+    # By default `beatbox` will assume we are trying to log in with a
+    # production account (i.e., using login.salesforce.com). If we want
+    # to use a sandbox, then we need to explicitly set the login url of
+    # our `beatbox` client.
+    if "test.salesforce.com" in settings_dict['HOST']:
+        soap_client.serverUrl = 'https://test.salesforce.com/services/Soap/u/33.0'
+    soap_client.login(settings_dict['USER'], settings_dict['PASSWORD'])
+
+    response = soap_client.convertLead({
+        'leadId': lead.pk,
+        'convertedStatus': converted_status,
+    })
+
+    return response


### PR DESCRIPTION
A new utility module that adds support for the Salesforce SOAP API in order to take advantage of the missing endpoints in the REST API (such as convertLead).
This feature requires an additional dependency as we use a third-party module to talk to the SOAP API: [beatbox](https://pypi.python.org/pypi/beatbox/32.1). However, this dependency is totally optional for users who do not need more than the capabilities offered by the REST API.

Launch the unit test with

```
./manage.py test salesforce.tests.test_utils
```