### PR TITLE
Cumulative change: Queries based on more ForeignKeys to the same table etc

### DIFF
--- a/salesforce/__init__.py
+++ b/salesforce/__init__.py
@@ -27,27 +27,3 @@ if django.VERSION[:2] >= (1, 8):
 				"carefully with Django 1.8")
 
 log = logging.getLogger(__name__)
-
-#TODO: Examine security: Compare the default SSL/TSL settings of urllib3 and SF.
-#      SSL protocol can be controlled according this docs:
-# http://docs.python-requests.org/en/latest/user/advanced/#example-specific-ssl-version
-#      Requests use 'urllib3', but the previous solution has been based on 'httplib2'.
-
-
-#import httplib2
-#
-#def ssl_wrap_socket(sock, key_file, cert_file, disable_validation, ca_certs):
-#	if disable_validation:
-#		cert_reqs = ssl.CERT_NONE
-#	else:
-#		cert_reqs = ssl.CERT_REQUIRED
-#	try:
-#		sock = ssl.wrap_socket(sock, keyfile=key_file, certfile=cert_file,
-#                               cert_reqs=cert_reqs, ca_certs=ca_certs, ssl_version=ssl.PROTOCOL_SSLv3)
-#	except ssl.SSLError:
-#		log.warning("SSL doesn't support PROTOCOL_SSLv3, trying PROTOCOL_SSLv23")
-#		sock = ssl.wrap_socket(sock, keyfile=key_file, certfile=cert_file,
-#                               cert_reqs=cert_reqs, ca_certs=ca_certs, ssl_version=ssl.PROTOCOL_SSLv23)
-#	return sock
-#
-#httplib2._ssl_wrap_socket = ssl_wrap_socket

--- a/salesforce/auth.py
+++ b/salesforce/auth.py
@@ -15,7 +15,7 @@ import threading
 from django.db import connections
 from salesforce.backend import sf_alias, MAX_RETRIES
 from salesforce.backend.driver import DatabaseError
-from requests.adapters import HTTPAdapter
+from salesforce.backend.adapter import SslHttpAdapter
 from requests.auth import AuthBase
 
 # TODO more advanced methods with ouathlib can be implemented, but the simple doesn't require a spec package
@@ -61,7 +61,7 @@ def authenticate(db_alias=None, settings_dict=None):
 				
 				log.info("attempting authentication to %s" % settings_dict['HOST'])
 				session = requests.Session()
-				session.mount(settings_dict['HOST'], HTTPAdapter(max_retries=MAX_RETRIES))
+				session.mount(settings_dict['HOST'], SslHttpAdapter(max_retries=MAX_RETRIES))
 				response = session.post(url, data=dict(
 					grant_type		= 'password',
 					client_id		= settings_dict['CONSUMER_KEY'],

--- a/salesforce/backend/__init__.py
+++ b/salesforce/backend/__init__.py
@@ -7,6 +7,16 @@
 
 """
 Database backend for the Salesforce API.
+
+No code in this directory is used with standard databases, even if a standard
+database is used for running some application tests on objects defined by
+SalesforceModel. All code for SF models that can be used with non SF databases
+should be located directly in the 'salesforce' directory in files 'models.py',
+'fields.py', 'manager.py', 'router.py', 'admin.py'.
+
+Incorrectly located files: (It is better not to change it now.)
+	backend/manager.py   => manager.py
+	auth.py              => backend/auth.py
 """
 
 import socket

--- a/salesforce/backend/adapter.py
+++ b/salesforce/backend/adapter.py
@@ -1,0 +1,20 @@
+"""requests adapter for more secure SSL"""
+# Motivated by "Salesforce recommends customers disable SSL 3.0 encryption":
+# https://help.salesforce.com/apex/HTViewSolution?urlname=Salesforce-disabling-SSL-3-0-encryption&language=en_US
+# Solution copied from:
+# http://docs.python-requests.org/en/latest/user/advanced/#example-specific-ssl-version
+
+import ssl
+from requests.adapters import HTTPAdapter, DEFAULT_POOLBLOCK
+from requests.packages.urllib3.poolmanager import PoolManager
+
+class SslHttpAdapter(HTTPAdapter):
+	"""Transport adapter with hardened SSL version."""
+
+	def init_poolmanager(self, connections, maxsize, block=DEFAULT_POOLBLOCK): 
+		ssl_version = ssl.PROTOCOL_TLSv1
+		self._pool_connections = connections 
+		self._pool_maxsize = maxsize 
+		self._pool_block = block 
+		self.poolmanager = PoolManager(num_pools=connections, maxsize=maxsize, 
+									   block=block, ssl_version=ssl_version) 

--- a/salesforce/backend/base.py
+++ b/salesforce/backend/base.py
@@ -33,6 +33,7 @@ from salesforce.backend.operations import DatabaseOperations
 from salesforce.backend.driver import IntegrityError, DatabaseError
 from salesforce.backend import driver as Database
 from salesforce.backend import sf_alias, MAX_RETRIES
+from salesforce.backend.adapter import SslHttpAdapter
 try:
 	from urllib.parse import urlparse
 except ImportError:
@@ -134,7 +135,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 					sf_instance_url = authenticate(self.alias, settings_dict=self.settings_dict)['instance_url']
 				sf_session = requests.Session()
 				sf_session.auth = SalesforceAuth(db_alias=self.alias)
-				sf_requests_adapter = requests.adapters.HTTPAdapter(max_retries=MAX_RETRIES)
+				sf_requests_adapter = SslHttpAdapter(max_retries=MAX_RETRIES)
 				sf_session.mount(sf_instance_url, sf_requests_adapter)
 				# Additional header works, but the improvement unmeasurable for me.
 				# (less than SF speed fluctuation)

--- a/salesforce/backend/compiler.py
+++ b/salesforce/backend/compiler.py
@@ -8,6 +8,7 @@
 """
 Generate queries using the SOQL dialect.
 """
+import re
 from django.db import models
 from django.db.models.sql import compiler, query, where, constants, AND, OR
 from django.db.models.sql.datastructures import EmptyResultSet
@@ -353,6 +354,26 @@ class SalesforceWhereNode(where.WhereNode):
 			# A match-everything node is different than empty node (which also
 			# technically matches everything) for backwards compatibility reasons.
 			# Refs #5261.
+
+			if DJANGO_17_PLUS:
+				# "rev" is a mapping from the table alias to the path in query
+				# structure tree, recursively reverse to join_map.
+				rev = {}
+				for k, v in qn.query.join_map.items():
+					if k[0] is None:
+						rev[k[1]] = k[1]
+				assert len(rev) == 1
+				xi = 0
+				#print('####', qn.query.join_map)
+				while len(rev) < len(qn.query.join_map) and xi < len(qn.query.join_map):
+					for k, v in qn.query.join_map.items():
+						if k[0] in rev:
+							rev[v[0]] = '.'.join((rev[k[0]], re.sub('\Id$', '', re.sub('__c$', '__r', k[2][0][0]))))
+					xi += 1
+				#print(rev, xi)
+				# Verify that the catch against infinite loop "xi" has not been reached.
+				assert xi < len(qn.query.join_map)
+
 			result = []
 			result_params = []
 			everything_childs, nothing_childs = 0, 0
@@ -374,6 +395,12 @@ class SalesforceWhereNode(where.WhereNode):
 					nothing_childs += 1
 				else:
 					if sql:
+						if DJANGO_17_PLUS:
+							x_match = re.match(r'(\w+)\.(.*)', sql)
+							if x_match:
+								x_table, x_field = x_match.groups()
+								sql = '%s.%s' % (rev[x_table], x_field)
+								#print('sql params:', sql, params)
 						result.append(sql)
 						result_params.extend(params)
 					else:
@@ -428,6 +455,13 @@ class SalesforceWhereNode(where.WhereNode):
 
 		as_salesforce = as_sql
 		del as_sql
+
+#	def as_salesforce(self, qn, connection):
+#		import pprint
+#		print('join_map:')
+#		pprint.PrettyPrinter(width=80).pprint(qn.query.join_map)
+#		import pdb; pdb.set_trace()
+#		return self.as_sql(qn, connection)
 
 
 class SQLInsertCompiler(compiler.SQLInsertCompiler, SQLCompiler):

--- a/salesforce/backend/compiler.py
+++ b/salesforce/backend/compiler.py
@@ -14,7 +14,7 @@ from django.db.models.sql import compiler, query, where, constants, AND, OR
 from django.db.models.sql.datastructures import EmptyResultSet
 
 from salesforce import DJANGO_15_PLUS, DJANGO_16_PLUS, DJANGO_17_PLUS, DJANGO_18_PLUS
-
+DJANGO_17_EXACT = DJANGO_17_PLUS and not DJANGO_18_PLUS
 
 class SQLCompiler(compiler.SQLCompiler):
 	"""
@@ -355,7 +355,7 @@ class SalesforceWhereNode(where.WhereNode):
 			# technically matches everything) for backwards compatibility reasons.
 			# Refs #5261.
 
-			if DJANGO_17_PLUS:
+			if DJANGO_17_EXACT:
 				# "rev" is a mapping from the table alias to the path in query
 				# structure tree, recursively reverse to join_map.
 				rev = {}
@@ -395,7 +395,7 @@ class SalesforceWhereNode(where.WhereNode):
 					nothing_childs += 1
 				else:
 					if sql:
-						if DJANGO_17_PLUS:
+						if DJANGO_17_EXACT:
 							x_match = re.match(r'(\w+)\.(.*)', sql)
 							if x_match:
 								x_table, x_field = x_match.groups()

--- a/salesforce/fields.py
+++ b/salesforce/fields.py
@@ -64,9 +64,9 @@ class SalesforceAutoField(fields.AutoField):
 
 	def contribute_to_class(self, cls, name):
 		name = name if self.name is None else self.name
-		if name != SF_PK or not self.primary_key:
-			raise ImproperlyConfigured("SalesforceAutoField must be a primary key "
-					"with name '%s' (as configured by settings)." % SF_PK)
+		if name != SF_PK or not self.primary_key or not self.auto_created:
+			raise ImproperlyConfigured("SalesforceAutoField must be an auto created "
+					"primary key with name '%s' (as configured by settings)." % SF_PK)
 		if cls._meta.has_auto_field:
 			if (type(self) == type(cls._meta.auto_field) and self.model._meta.abstract and
 					cls._meta.auto_field.name == SF_PK):

--- a/salesforce/fields.py
+++ b/salesforce/fields.py
@@ -113,6 +113,10 @@ class SfField(models.Field):
 		#                appended.
 		#   * column:    The database column for this field. This is the same as
 		#                "attname", except if db_column is specified.
+		if isinstance(self, ForeignKey):
+			#print(self.name)
+			pass
+			#import pdb; pdb.set_trace()
 		attname = self.get_attname()
 		if self.db_column is not None:
 			# explicit name

--- a/salesforce/management/commands/inspectdb.py
+++ b/salesforce/management/commands/inspectdb.py
@@ -3,9 +3,71 @@ import warnings
 from optparse import make_option
 from django.core.management.commands.inspectdb import Command as InspectDBCommand
 from django.db import connections, DEFAULT_DB_ALIAS
+from django.utils import six
 from salesforce.backend import introspection as sf_introspection
+from salesforce import DJANGO_15_PLUS
 import django
 import salesforce
+
+try:
+	from collections import OrderedDict
+except ImportError:
+	# Python 2.6-
+	from django.utils.datastructures import SortedDict as OrderedDict
+
+
+def fix_field_params_repr(params):
+	"""
+	Fixes repr() of "field_params" for Python 2 with future unicode_literals.
+	"""
+	class ReprUnicode(six.text_type):
+		def __new__(cls, text):
+			return unicode.__new__(cls, text)
+		def __repr__(self):
+			out = repr(unicode(self))
+			return out[1:] if out.startswith("u'") or out.startswith('u"') else out
+	class ReprChoices(list):
+		def __new__(cls, choices):
+			return list.__new__(cls, choices)
+		def __repr__(self):
+			out = []
+			for x0, x1 in self:
+				out.append('(%s, %s)' % (
+						repr(ReprUnicode(x0) if isinstance(x0, unicode) else x0),
+						repr(ReprUnicode(x1) if isinstance(x1, unicode) else x1)
+				))
+			return '[%s]' % (', '.join(out))
+	if not DJANGO_15_PLUS or six.PY3:
+		return params
+	out = OrderedDict()
+	for k, v in params.items():
+		if k == 'choices' and v:
+			v = ReprChoices(v)
+		elif isinstance(v, unicode):
+			v = ReprUnicode(v)
+		out[k] = v
+	return out
+
+def fix_international(text):
+	"Fix excaped international characters back to utf-8"
+	class SmartInternational(str):
+		def __new__(cls, text):
+			return str.__new__(cls, text)
+		def endswith(self, string):
+			return super(SmartInternational, self).endswith(str(string))
+	if six.PY3:
+		return text
+	out = []
+	last = 0
+	for match in re.finditer(r'(?<=[^\\])(?:\\x[0-9a-f]{2}|\\u[0-9a-f]{4})', text):
+		start, end, group = match.start(), match.end(), match.group()
+		out.append(text[last:start])
+		c = group.decode('unicode_escape')
+		out.append(c if ord(c) >160 and ord(c) != 173 else group)
+		last = end
+	out.append(text[last:])
+	return SmartInternational(''.join(out).encode('utf-8'))
+
 
 class Command(InspectDBCommand):
 	# This will export Salestorce to a valid models.py, if Django >=1.5.
@@ -22,6 +84,8 @@ class Command(InspectDBCommand):
 			options['table_name_filter'] = re.compile(options['table_name_filter']).match
 		self.connection = connections[options['database']]
 		if self.connection.vendor == 'salesforce':
+			if not six.PY3:
+				self.stdout.write("# coding: utf-8\n")
 			self.db_module = 'salesforce'
 			for line in self.handle_inspection(options):
 				line = line.replace(" Field renamed because it contained more than one '_' in a row.", "")
@@ -32,7 +96,7 @@ class Command(InspectDBCommand):
 				elif django.VERSION[:2] == (1,5):
 					# fix bug in Django 1.5
 					line = line.replace("''self''", "'self'")
-				self.stdout.write("%s\n" % line)
+				self.stdout.write(fix_international("%s\n" % line))
 		else:
 			super(Command, self).handle_noargs(**options)
 
@@ -42,8 +106,10 @@ class Command(InspectDBCommand):
 				).get_field_type(connection, table_name, row)
 		if connection.vendor == 'salesforce':
 			name, type_code, display_size, internal_size, precision, scale, null_ok, sf_params = row
+			if 'ref_comment' in sf_params:
+				field_notes.append(sf_params.pop('ref_comment'))
 			field_params.update(sf_params)
-		return field_type, field_params, field_notes
+		return field_type, fix_field_params_repr(field_params), field_notes
 
 	def normalize_col_name(self, col_name, used_column_names, is_relation):
 		if self.connection.vendor == 'salesforce':
@@ -53,15 +119,19 @@ class Command(InspectDBCommand):
 			new_name, field_params, field_notes = super(Command, self
 					).normalize_col_name(beautified, used_column_names, is_relation)
 			# *reconstructed* : is what will SfField reconstruct to db column
+			field_params = OrderedDict(sorted(field_params.items()))
 			reconstructed = new_name.title().replace('_', '')
 			if col_name.endswith('__c'):
 				reconstructed += '__c'
 				field_params['custom'] = True
 			elif is_relation:
 				reconstructed += 'Id'
-			# TODO: Discuss whether 'db_column' should be rather compared case insensitive
-			if reconstructed != col_name or 'db_column' in field_params:
+			# TODO: Discuss: Maybe 'db_column' can be compared case insensitive,
+			#       but exact compare is safer.
+			if reconstructed != col_name:
 				field_params['db_column'] = col_name
+			else:
+				field_params.pop('db_column', None)
 			if is_relation:
 				if col_name in sf_introspection.last_with_important_related_name:
 					field_params['related_name'] = '%s_%s_set' % (
@@ -71,10 +141,12 @@ class Command(InspectDBCommand):
 				if col_name in sf_introspection.last_read_only:
 					field_params['sf_read_only'] = sf_introspection.last_read_only[col_name]
 				field_params['on_delete'] = sf_introspection.SymbolicModelsName('DO_NOTHING')
+				if len(sf_introspection.last_refs[col_name]) > 1:
+					field_notes.append('Reference to tables [%s]' % (', '.join(sf_introspection.last_refs[col_name])))
 		else:
 			new_name, field_params, field_notes = super(Command, self
 					).normalize_col_name(col_name, used_column_names, is_relation)
-		return new_name, field_params, field_notes
+		return new_name, fix_field_params_repr(field_params), field_notes
 
 	def get_meta(self, table_name):
 		"""

--- a/salesforce/models.py
+++ b/salesforce/models.py
@@ -26,7 +26,11 @@ from django.db.models import PROTECT, DO_NOTHING
 
 from salesforce.backend import manager
 from salesforce.fields import *  # modified django.db.models.CharField etc.
-from salesforce import fields
+from salesforce import fields, DJANGO_17_PLUS
+if DJANGO_17_PLUS:
+	from django.utils.deconstruct import deconstructible
+else:
+	deconstructible = lambda x: x
 
 log = logging.getLogger(__name__)
 
@@ -96,4 +100,23 @@ class SalesforceModel(with_metaclass(SalesforceModelBase, models.Model)):
 									verbose_name='ID', auto_created=True)
 
 
+@deconstructible
+class DefaultedOnCreate(object):
+	"""
+	Default value for foreign keys that but will get a smart auto value from
+	SFDC on create if the field is omitted, but can not be assigned to null in
+	the API.
+	(builtin SFDC fields with attributes 'defaultedOnCreate: true, nillable: false')
+
+	Example: `Owner` field is assigned to the current user if the field User is omitted.
+
+		Owner = models.ForeignKey(User, on_delete=models.DO_NOTHING,
+				default=models.DefaultedOnCreate(),
+				db_column='OwnerId')
+	"""
+	def __str__(self):
+		return 'DEFAULTED_ON_CREATE'
+
+
+DEFAULTED_ON_CREATE = DefaultedOnCreate()
 Model = SalesforceModel

--- a/salesforce/models.py
+++ b/salesforce/models.py
@@ -13,6 +13,7 @@ column names are all in CamelCase. No attempt is made to work around this
 issue, but normal use of `db_column` and `db_table` parameters should work.
 """
 
+from __future__ import unicode_literals
 import logging
 
 from django.conf import settings
@@ -76,7 +77,7 @@ def with_metaclass(meta, *bases):
 			if this_bases is None:
 				return type.__new__(cls, name, (), d)
 			return meta(name, bases, d)
-	return metaclass('temporary_class', None, {})
+	return metaclass(str('temporary_class'), None, {})
 
 
 class SalesforceModel(with_metaclass(SalesforceModelBase, models.Model)):

--- a/salesforce/models.py
+++ b/salesforce/models.py
@@ -92,7 +92,8 @@ class SalesforceModel(with_metaclass(SalesforceModelBase, models.Model)):
 
 	# Name of primary key 'Id' can be easily changed to 'id'
 	# by "settings.SF_PK='id'".
-	Id = fields.SalesforceAutoField(primary_key=True, name=SF_PK, db_column='Id')
+	id = fields.SalesforceAutoField(primary_key=True, name=SF_PK, db_column='Id',
+									verbose_name='ID', auto_created=True)
 
 
 Model = SalesforceModel

--- a/salesforce/testrunner/example/admin.py
+++ b/salesforce/testrunner/example/admin.py
@@ -6,23 +6,12 @@
 #
 
 from django.contrib import admin
-#from django.db import models   # This name is overwritten by example.models below
-from django.forms import widgets
-from django.http import HttpResponse
-
 from salesforce.testrunner.example import models
-import salesforce
+from salesforce.testrunner.example.universal_admin import register_omitted_classes
 
 class AccountAdmin(admin.ModelAdmin):
 	#list_display = ('Salutation', 'Name', 'PersonEmail')
 	list_display = ('Name', 'Phone')
 admin.site.register(models.Account, AccountAdmin)
 
-# Simple dynamic registration of all other models, with respect to read only fields.
-# Can be improved for fields that are only not creatable but are updateable or viceversa.
-for mdl in [x for x in models.__dict__.values() if hasattr(x, '_meta') and hasattr(x._meta, 'db_table') and not x._meta.abstract]:
-	try:
-		admin.site.register(mdl, type(type(mdl).__name__ + 'Admin', (admin.ModelAdmin,), {
-			'readonly_fields': [x.name for x in mdl._meta.fields if getattr(x, 'sf_read_only', 0)]}))
-	except admin.sites.AlreadyRegistered:
-		pass
+register_omitted_classes(models)

--- a/salesforce/testrunner/example/models.py
+++ b/salesforce/testrunner/example/models.py
@@ -6,11 +6,12 @@
 #
 
 from __future__ import unicode_literals
-from salesforce import models
+from salesforce import models, DJANGO_15_PLUS
 from salesforce.models import SalesforceModel as SalesforceModelParent
 
 import django
 from django.conf import settings
+from django.utils.encoding import python_2_unicode_compatible
 
 SALUTATIONS = [
 	'Mr.', 'Ms.', 'Mrs.', 'Dr.', 'Prof.'
@@ -41,6 +42,7 @@ class User(SalesforceModel):
 	IsActive = models.BooleanField(default=False)
 
 
+@python_2_unicode_compatible
 class AbstractAccount(SalesforceModel):
 	"""
 	Default Salesforce Account model.
@@ -51,7 +53,7 @@ class AbstractAccount(SalesforceModel):
 	]
 
 	Owner = models.ForeignKey(User, on_delete=models.DO_NOTHING,
-			default=lambda:User(pk='DEFAULT'),
+			default=models.DEFAULTED_ON_CREATE,
 			db_column='OwnerId')
 	Type = models.CharField(max_length=100, choices=[(x, x) for x in TYPES],
 							null=True)
@@ -81,7 +83,7 @@ class AbstractAccount(SalesforceModel):
 	class Meta(SalesforceModel.Meta):
 		abstract = True
 
-	def __unicode__(self):
+	def __str__(self):
 		return self.Name
 
 
@@ -114,6 +116,7 @@ else:
 		pass
 
 
+@python_2_unicode_compatible
 class Contact(SalesforceModel):
 	# Example that db_column is not necessary for most of fields even with
 	# lower case names and for ForeignKey
@@ -129,13 +132,14 @@ class Contact(SalesforceModel):
 	# problematic with migrations in the future because it is not serializable.
 	# It can be replaced by normal function.
 	owner = models.ForeignKey(User, on_delete=models.DO_NOTHING,
-			default=lambda:User(pk='DEFAULT'),
+			default=models.DEFAULTED_ON_CREATE,
 			related_name='contact_owner_set')
 
-	def __unicode__(self):
+	def __str__(self):
 		return self.name
 
 
+@python_2_unicode_compatible
 class Lead(SalesforceModel):
 	"""
 	Default Salesforce Lead model.
@@ -185,31 +189,40 @@ class Lead(SalesforceModel):
 											sf_read_only=models.NOT_CREATEABLE)
 	# Deleted object can be found only in querysets with "query_all" SF method.
 	IsDeleted = models.BooleanField(default=False, sf_read_only=models.READ_ONLY)
+	owner = models.ForeignKey(User, on_delete=models.DO_NOTHING,
+			default=models.DEFAULTED_ON_CREATE,
+			related_name='lead_owner_set')
+	last_modified_by = models.ForeignKey(User, on_delete=models.DO_NOTHING,
+			sf_read_only=models.READ_ONLY,
+			related_name='lead_lastmodifiedby_set')
 
-	def __unicode__(self):
+	def __str__(self):
 		return self.Name
 
 
+@python_2_unicode_compatible
 class Product(SalesforceModel):
 	Name = models.CharField(max_length=255)
 
 	class Meta(SalesforceModel.Meta):
 		db_table = 'Product2'
 
-	def __unicode__(self):
+	def __str__(self):
 		return self.Name
 
 
+@python_2_unicode_compatible
 class Pricebook(SalesforceModel):
 	Name = models.CharField(max_length=255)
 
 	class Meta(SalesforceModel.Meta):
 		db_table = 'Pricebook2'
 
-	def __unicode__(self):
+	def __str__(self):
 		return self.Name
 
 
+@python_2_unicode_compatible
 class PricebookEntry(SalesforceModel):
 	Name = models.CharField(max_length=255, db_column='Name', sf_read_only=models.READ_ONLY)
 	Pricebook2 = models.ForeignKey('Pricebook', on_delete=models.DO_NOTHING)
@@ -221,7 +234,7 @@ class PricebookEntry(SalesforceModel):
 		db_table = 'PricebookEntry'
 		verbose_name_plural = "PricebookEntries"
 
-	def __unicode__(self):
+	def __str__(self):
 		return self.Name
 
 
@@ -281,7 +294,7 @@ class TestCustomExample(SalesforceParentModel):
 		>> install_metadata_service()
 		>> create_demo_test_object()
 	
-	or create an object with `API Name`: `Test__c`
+	or create an object with `API Name`: `django_Test__c`
 	`Data Type` of the Record Name: `Text`
 	with a text field `API Name`: `TestField__c`.
 	and set it accessible by you. (`Set Field-Leved Security`)
@@ -290,7 +303,7 @@ class TestCustomExample(SalesforceParentModel):
 	# The API name is therefore 'TestField__c'
 	test_field = models.CharField(max_length=42)
 	class Meta:
-		db_table = 'Test__c'
+		db_table = 'django_Test__c'
 		custom = True
 
 
@@ -328,3 +341,32 @@ class OpportunityContactRole(models.Model):
 	opportunity = models.ForeignKey(Opportunity, on_delete=models.DO_NOTHING, related_name='contact_roles')
 	contact = models.ForeignKey(Contact, on_delete=models.DO_NOTHING, related_name='opportunity_roles')
 	role = models.CharField(max_length=40, blank=True, null=True)  # e.g. "Business User"
+
+
+class Organization(models.Model):
+    name = models.CharField(max_length=80, sf_read_only=models.NOT_CREATEABLE)
+    division = models.CharField(max_length=80, sf_read_only=models.NOT_CREATEABLE, blank=True)
+    organization_type = models.CharField(max_length=40, verbose_name='Edition',
+    		sf_read_only=models.READ_ONLY) # e.g 'Developer Edition', Enteprise, Unlimited...
+    instance_name = models.CharField(max_length=5, sf_read_only=models.READ_ONLY, blank=True)
+    is_sandbox = models.BooleanField(sf_read_only=models.READ_ONLY)
+
+
+# Skipping the model if a custom table isn't installed in your Salesforce
+# is important an old Django, even with "on_delete=DO_NOTHING",
+# due to how "delete" was implemented in Django 1.4
+if DJANGO_15_PLUS or getattr(settings, 'SF_TEST_TABLE_INSTALLED', False):
+
+	class Test(models.Model):
+		test_text = models.CharField(max_length=40)
+		test_bool = models.BooleanField(default=False)
+		contact = models.ForeignKey(Contact, null=True, on_delete=models.DO_NOTHING)
+		class Meta:
+			custom = True
+			db_table = 'django_Test__c'
+
+
+	class NoteAttachment(models.Model):
+		# A standard SFDC object that can have a relationship to any custom object
+		parent = models.ForeignKey(Test, sf_read_only=models.NOT_UPDATEABLE, on_delete=models.DO_NOTHING)
+		title = models.CharField(max_length=80)

--- a/salesforce/testrunner/example/models.py
+++ b/salesforce/testrunner/example/models.py
@@ -5,6 +5,7 @@
 # See LICENSE.md for details
 #
 
+from __future__ import unicode_literals
 from salesforce import models
 from salesforce.models import SalesforceModel as SalesforceModelParent
 

--- a/salesforce/testrunner/example/universal_admin.py
+++ b/salesforce/testrunner/example/universal_admin.py
@@ -1,0 +1,27 @@
+"""
+Simple dynamic registration of admin for all yet unregistered models,
+for demonstration, with respect to read only fields.
+"""
+from django.contrib import admin
+import salesforce
+
+def register_omitted_classes(models):
+	"""
+	Register classes that don't have an own admin yet.
+	Example:
+		register_omitted_classes(some_app.models)
+	"""
+	# This can be improved for fields that are only not creatable but are updateable or viceversa.
+	for mdl in models.__dict__.values():
+		if hasattr(mdl, '_salesforce_object') and not mdl._meta.abstract:
+			try:
+				admin.site.register(
+					mdl,
+					type(
+						type(mdl).__name__ + 'Admin',
+						(admin.ModelAdmin,),
+						{'readonly_fields': [mdl.name for mdl in mdl._meta.fields if getattr(mdl, 'sf_read_only', 0)]}
+					)
+				)
+			except admin.sites.AlreadyRegistered:
+				pass

--- a/salesforce/tests/test_auth.py
+++ b/salesforce/tests/test_auth.py
@@ -7,12 +7,16 @@
 
 from django.test import TestCase
 from django.conf import settings
-from django.utils.unittest import skipUnless
 
 from salesforce import auth
 from salesforce.backend import sf_alias
 from salesforce.testrunner.example import models
 from salesforce.tests.test_integration import default_is_sf
+try:
+	from unittest import skip, skipUnless
+except ImportError:
+	# old Python 2.6 (Django 1.4 - 1.6 simulated unittest2)
+	from django.utils.unittest import skip, skipUnless
 
 import logging
 log = logging.getLogger(__name__)

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -14,7 +14,6 @@ from django.conf import settings
 from django.db import connections
 from django.db.models import Q, Avg, Count, Sum, Min, Max
 from django.test import TestCase
-from django.utils.unittest import skip, skipUnless
 from django.utils import timezone
 
 from salesforce.testrunner.example.models import (Account, Contact, Lead, User,
@@ -24,6 +23,11 @@ from salesforce.testrunner.example.models import (Account, Contact, Lead, User,
 from salesforce import router, DJANGO_15_PLUS
 from salesforce.backend import sf_alias
 import salesforce
+try:
+	from unittest import skip, skipUnless
+except ImportError:
+	# old Python 2.6 (Django 1.4 - 1.6 simulated unittest2)
+	from django.utils.unittest import skip, skipUnless
 
 import logging
 log = logging.getLogger(__name__)

--- a/salesforce/tests/test_utils.py
+++ b/salesforce/tests/test_utils.py
@@ -7,6 +7,11 @@ from salesforce.testrunner.example.models import Account, Contact, Lead, Opportu
 from salesforce.utils import convert_lead
 
 try:
+	from unittest import skip, skipUnless
+except ImportError:
+	# old Python 2.6 (Django 1.4 - 1.6 simulated unittest2)
+	from django.utils.unittest import skip, skipUnless
+try:
     import beatbox
 except ImportError:
     beatbox = None
@@ -14,7 +19,7 @@ except ImportError:
 
 class UtilitiesTest(TestCase):
 
-    @unittest.skipUnless(beatbox, "Beatbox needs to be installed in order to run this test.")
+    @skipUnless(beatbox, "Beatbox needs to be installed in order to run this test.")
     def test_lead_conversion(self):
         """
         Create a Lead object within Salesforce and try to

--- a/tests/inspectdb/admin.py
+++ b/tests/inspectdb/admin.py
@@ -1,0 +1,5 @@
+from __future__ import absolute_import
+from . import models
+from salesforce.testrunner.example.universal_admin import register_omitted_classes
+
+register_omitted_classes(models)

--- a/tests/inspectdb/slow_test.py
+++ b/tests/inspectdb/slow_test.py
@@ -68,6 +68,8 @@ def run():
 					'StaticResource', 'WebLink',
 					# This is not writable due to 'NamespacePrefix' field
 					'ApexPage',
+					# Some Leads are not writable becase they are coverted to Contact
+					'Lead',
 					# Insufficient access rights on cross-reference id
 					'Group',
 					'OpportunityShare', 'Profile',

--- a/tests/inspectdb/test.sh
+++ b/tests/inspectdb/test.sh
@@ -13,7 +13,7 @@ if python manage.py inspectdb --database=salesforce --traceback >tests/inspectdb
 	RESULT_2=$?
 
 	echo "*** parse test ***"
-	python -m unittest tests.inspectdb.tests
+	DJANGO_SETTINGS_MODULE=salesforce.testrunner.settings python -m unittest tests.inspectdb.tests
 	#python manage.py test --settings=tests.inspectdb.settings tests.inspectdb
 	RESULT_3=$?
 

--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -1,8 +1,12 @@
 """Tests by parsing the file modules.py exported by inspectdb."""
-from collections import OrderedDict
-from unittest import TestCase
+import unittest
 import os
 import re
+
+try:
+	from collections import OrderedDict
+except ImportError:
+	from django.utils.datastructures import SortedDict as OrderedDict
 
 
 def relative_path(path):
@@ -18,6 +22,7 @@ def get_classes_texts():
 	"""
 	result = OrderedDict()
 	excluded_pattern = re.compile(r'^('
+			r'# coding: utf-8|'
 			r'# This is an auto-generated Django model|'
 			r'from salesforce import models$'
 		')')
@@ -30,7 +35,7 @@ def get_classes_texts():
 	return result
 
 
-class ExportedModelTest(TestCase):
+class ExportedModelTest(unittest.TestCase):
 	def test_nice_fields_names(self):
 		"""Test the typical nice field name 'last_modified_date'."""
 		for text in classes_texts.values():
@@ -58,3 +63,6 @@ class ExportedModelTest(TestCase):
 			self.skipTest("The model for the table Test__c not exported.")
 
 classes_texts = get_classes_texts()
+
+if __name__ == '__main__':
+	unittest.main()

--- a/tests/test_compatibility/models.py
+++ b/tests/test_compatibility/models.py
@@ -1,4 +1,4 @@
-"""Demonstrate that a Model can inherite from more abstract models."""
+"""Backward compatible behaviour with primary key 'Id' and upper-case field names"""
 
 from django.conf import settings
 import salesforce

--- a/tests/test_compatibility/tests.py
+++ b/tests/test_compatibility/tests.py
@@ -21,3 +21,13 @@ class CompatibilityTest(TestCase):
 			repr(test_lead.__dict__)
 		finally:
 			test_lead.delete()
+
+
+class DjangoCompatibility(TestCase):
+	def test_autofield_compatible(self):
+		"""Test that the light weigh AutoField is compatible in all Django ver."""
+		primary_key = [x for x in Lead._meta.fields if x.primary_key][0]
+		self.assertEqual(primary_key.auto_created, True)
+		self.assertEqual(primary_key.get_internal_type(), 'AutoField')
+		self.assertIn(primary_key.name, ('id', 'Id'))
+

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,8 @@ minversion = 1.6.1
 # and the lowest versions.
 # These environment are tested only with `tox -e ALL`:
 #     py27dj14, py27dj15, py27dj16, py34dj16
-envlist = py26dj14, py27dj17, py27dj18, py33dj17
+envlist = py26dj14, py27dj17, py33dj17
+# TODO Add py27dj18 after fixing it for Django 1.8
 [testenv]
 basepython = python2.7
 deps =


### PR DESCRIPTION
This is a cumulative pull request with finished more than a half of my development since November.

- It is possible to write filters with more foreign keys related to the same model..
- More compatibility with standard Django + migrations (no real migrations, but very useful if the development is done on any standard Django database), serializable default values etc.
- Improved introspection, supported DEFAULTED_ON_CREATE, better comments to exported models, complete compatibility betwen Python 2 and 3.
- Fixed SSL protocol settings to current security requirements
