### PR TITLE
match converted_status to default schema

### DIFF
--- a/salesforce/utils.py
+++ b/salesforce/utils.py
@@ -19,7 +19,7 @@ except ImportError:
     beatbox = None
 
 
-def convert_lead(lead, converted_status="Qualified - converted"):
+def convert_lead(lead, converted_status="Qualified"):
     """
     Convert `lead` using the `convertLead()` endpoint exposed
     by the SOAP API.


### PR DESCRIPTION
I've been working against a default Salesforce install. It seems that the default picklist values for the Lead->LeadStatus field only include 'Contacted', 'Open', 'Qualified', 'Unqualified'. The error thrown was a bit cryptic:

```Lead conversion failed: Statusinvalid convertedStatus: Qualified - convertedINVALID_STATUS, leadId=...```

I eventually tracked it down as being a default value for the convert_lead() method. I wonder if this should be surfaced more visibly as a configuration parameter?

Btw, thanks for this library!