### PR TITLE
Some fixes for Django 1.8, Tests for SSL, filter with similar FK etc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -322,6 +322,17 @@ the old insecure protocols including SSL v3 are disabled unless you've installed
 PyOpenSSL. As long as you have *not* installed PyOpenSSL, it's recommended you
 update your settings to use `PROTOCOL_SSLv23`.
 
+The test of readiness for TLS better than 1.0 and a test of disabled SSL 3
+are run by all tests. These tests give also some suggestions for the tested machine.
+More tests for SSL/TLS client security by popular SSL evaluation sites can be
+run by the command ::
+
+   python manage.py test salesforce.tests.test_ssl.SslTest
+
+Additional tests are skipped without the word `SslTest` on the command line,
+because some vulnerabilities are hopefully not (so?) important for connections
+to SFDC.
+
 If you have an old Python, you can improve security a little (SNI, validation of
 certificates, fixed InsecurePlatformWarning) by additional packages:
 
@@ -330,10 +341,9 @@ certificates, fixed InsecurePlatformWarning) by additional packages:
 These have dependencies on the libffi development libararies. Install `libffi-dev` on
 Debian/Ubuntu or `libffi-devel` on RedHat derivatives.
 
-Hoever, once you're using Python 2.7.9 and newer or Python 3.4.0 and newer, installing
-pyOpenSSL enables SSLv3 again. If you *must* install PyOpenSSL on these Python versions,
-it is more secure to use ssl.PROTOCOL_TLSv1 than other protocols, as even if you
-set PROTOCOL_SSLv23 you are open to a downgrade attack to an older SSL protocol.
+However, once you're using Python 2.7.9 and newer or Python 3.4.0 and newer, installing
+pyOpenSSL can enable SSLv3 again. If you *must* install PyOpenSSL on these Python versions,
+it is more secure to use ssl.PROTOCOL_TLSv1 than other protocols.
 
 Ultimately this will become moot for users of django-salesforce, as SFDC will soon require
 the updated setting.

--- a/README.rst
+++ b/README.rst
@@ -217,6 +217,14 @@ Advanced usage
 -  **Meta class options** - If an inner ``Meta`` class is used, it must be a
    descendant of ``SalesforceModel.Meta`` or must have ``managed=False``.
 
+-  **Query deleted objects** - Deleted objects that are in trash bin are
+   not selected by a normal queryset, but if a special method `query_all`
+   is used then also deleted objects are searched.
+   If a trash bin is supported by the model then a boolean field `IsDeleted`
+   can be in the model and it is possible to select only deleted objects ::
+
+     deleted_list = list(Lead.objects.filter(IsDeleted=True).query_all())
+
 Introspection and special attributes of fields
 ----------------------------------------------
 Some Salesforce fields can not be fully used without special attributes. You

--- a/README.rst
+++ b/README.rst
@@ -225,6 +225,17 @@ Advanced usage
 
      deleted_list = list(Lead.objects.filter(IsDeleted=True).query_all())
 
+-  **Migrations** - Migrations can be used for an alternate test database
+   with SalesforceModel. Then all tables must have Meta `managed = True` and
+   attributes db_table and db_column are required. (Migrations in SFDC
+   will be probably never supported, though it was experimantally tested
+   creation of a new simple table in sandbox if a development patch is
+   applied and permissions increased. If anything would be implemented after
+   all, a new attribute will be added to SalesforceModel for safe forward
+   compatibility. Consequently, the setting `managed = True` can be considered
+   safe as it is related only to the alternate non SFDC database configured
+   by `SF_ALIAS`.)
+
 Introspection and special attributes of fields
 ----------------------------------------------
 Some Salesforce fields can not be fully used without special attributes. You
@@ -267,6 +278,12 @@ can see in the output of ``inspectdb`` in the most complete form.
    In this example, inspectdb will only export models for tables with exact
    name ``Contact`` and all tables that are prefixed with ``Account``. This
    filter works with all supported database types.
+
+-  **Verbosity** - This package can set correct column names for Salesforce
+   without explicit attribute ``db_column`` for many objects automatically.
+   These attributes are not exported if a default verbosity is used. This is
+   intended for use only with SFDC. If an alternate non SFDC test database
+   is also expected and migrations of any SalesforceModel will 
 
 -  **Accessing the Salesforce SOAP API** - There are some Salesforce actions that cannot or can hardly
    be implemented using the generic relational database abstraction and the REST API.

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ django-salesforce
 This library allows you to load and edit the objects in any Salesforce instance
 using Django models. The integration is fairly complete, and generally seamless
 for most uses. It works by integrating with the Django ORM, allowing access to
-the objects in your SFDC instance as if they were in a traditional database.
+the objects in your SFDC instance (Salesforce .com) as if they were in a traditional database.
 
 Python 2.6, 2.7, 3.3, 3.4 or pypy; Django 1.4.2 - 1.7, partly Django 1.8.
 The best supported version is currently Django 1.7, including relative

--- a/salesforce/backend/adapter.py
+++ b/salesforce/backend/adapter.py
@@ -10,14 +10,25 @@ from requests.adapters import HTTPAdapter, DEFAULT_POOLBLOCK
 from requests.packages.urllib3.poolmanager import PoolManager
 
 class SslHttpAdapter(HTTPAdapter):
-	"""Transport adapter with hardened SSL version."""
+	"""
+	Transport adapter with hardened SSL version.
+
+	ssl_version: this parameter is inteded for tests to override the value
+			`SF_SSL['ssl_version']`.
+			Expected values are `ssl.PROTOCOL_TLSv1` or `ssl.PROTOCOL_SSLv23`.
+	"""
+	def __init__(self, *args, **kwargs):
+		# TODO Change the default SSL version to ssl.PROTOCOL_SSLv23 in the
+		#      autumn release v0.7.
+		default_ssl_version = getattr(settings, 'SF_SSL', {}).get('ssl_version',
+				ssl.PROTOCOL_TLSv1)
+		self.sf_ssl_version = kwargs.pop('ssl_version', default_ssl_version)
+		super(SslHttpAdapter, self).__init__(*args, **kwargs)
 
 	def init_poolmanager(self, connections, maxsize, block=DEFAULT_POOLBLOCK):
-		# TODO Change the default value to ssl.PROTOCOL_SSLv23 in the autumn release v0.7.
-		default_ssl_version = ssl.PROTOCOL_TLSv1
-		ssl_version = getattr(settings, 'SF_SSL', {}).get('ssl_version', default_ssl_version)
 		self._pool_connections = connections
 		self._pool_maxsize = maxsize
 		self._pool_block = block
 		self.poolmanager = PoolManager(num_pools=connections, maxsize=maxsize,
-									   block=block, ssl_version=ssl_version)
+									   block=block,
+									   ssl_version=self.sf_ssl_version)

--- a/salesforce/backend/compiler.py
+++ b/salesforce/backend/compiler.py
@@ -370,7 +370,7 @@ class SalesforceWhereNode(where.WhereNode):
 						if v.parent_alias in rev:
 							lhs_field =  re.sub('\Id$', '', re.sub('__c$', '__r', v.join_cols[0][0]))
 							rev[v.table_alias] = '.'.join((rev[v.parent_alias], lhs_field))
-							assert len(v.join_cols) == 1 and v.join_cols[0][1] == 'Id'
+							assert len(v.join_cols) == 1 and len(v.join_cols[0]) == 2 and v.join_cols[0][1] == 'Id'
 					xi += 1
 				#print(rev, xi)
 				# Verify that the catch against infinite loop "xi" has not been reached.

--- a/salesforce/backend/introspection.py
+++ b/salesforce/backend/introspection.py
@@ -13,6 +13,7 @@ import logging
 import re
 
 from salesforce import models, DJANGO_15_PLUS, DJANGO_18_PLUS
+from salesforce.fields import SF_PK
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -114,6 +115,9 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
 			del self._table_description_cache[table]['fields'][0]
 		return self._table_description_cache[table]
 	
+	def table_name_converter(self, name):
+		return name if name.lower() != 'id' else SF_PK
+
 	def get_table_list(self, cursor):
 		"Returns a list of table names in the current database."
 		result = [SfProtectName(x['name'])

--- a/salesforce/backend/query.py
+++ b/salesforce/backend/query.py
@@ -271,7 +271,8 @@ class SalesforceQuerySet(query.QuerySet):
 				if model is None:
 					model = self.model
 				try:
-					if field.name in only_load[model]:
+					selected_name = field.attname if DJANGO_18_PLUS else field.name
+					if selected_name in only_load[model]:
 						# Add a field that has been explicitly included
 						load_fields.append(field.name)
 				except KeyError:

--- a/salesforce/backend/query.py
+++ b/salesforce/backend/query.py
@@ -41,7 +41,7 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
-API_STUB = '/services/data/v32.0'
+API_STUB = '/services/data/v34.0'
 
 # Values of seconds are with 3 decimal places in SF, but they are rounded to
 # whole seconds for the most of fields.

--- a/salesforce/backend/query.py
+++ b/salesforce/backend/query.py
@@ -317,7 +317,7 @@ class SalesforceRawQuery(RawQuery):
 		converter = connections[self.using].introspection.table_name_converter
 		if self.cursor.rowcount > 0:
 			return [converter(col) for col in self.cursor.first_row.keys() if col != 'attributes']
-		return ['Id']
+		return [SF_PK]
 
 	def _execute_query(self):
 		self.cursor = CursorWrapper(connections[self.using], self)

--- a/salesforce/management/commands/inspectdb.py
+++ b/salesforce/management/commands/inspectdb.py
@@ -82,6 +82,7 @@ class Command(InspectDBCommand):
 	def handle_noargs(self, **options):
 		if isinstance(options['table_name_filter'], str):
 			options['table_name_filter'] = re.compile(options['table_name_filter']).match
+		self.verbosity = int(options['verbosity'])
 		self.connection = connections[options['database']]
 		if self.connection.vendor == 'salesforce':
 			if not six.PY3:
@@ -128,7 +129,7 @@ class Command(InspectDBCommand):
 				reconstructed += 'Id'
 			# TODO: Discuss: Maybe 'db_column' can be compared case insensitive,
 			#       but exact compare is safer.
-			if reconstructed != col_name:
+			if reconstructed != col_name or self.verbosity >= 2:
 				field_params['db_column'] = col_name
 			else:
 				field_params.pop('db_column', None)

--- a/salesforce/management/commands/inspectdb.py
+++ b/salesforce/management/commands/inspectdb.py
@@ -132,7 +132,7 @@ class Command(InspectDBCommand):
 			if reconstructed != col_name or self.verbosity >= 2:
 				field_params['db_column'] = col_name
 			else:
-				field_params.pop('db_column', None)
+				field_params.pop('db_column')
 			if is_relation:
 				if col_name in sf_introspection.last_with_important_related_name:
 					field_params['related_name'] = '%s_%s_set' % (

--- a/salesforce/testrunner/example/models.py
+++ b/salesforce/testrunner/example/models.py
@@ -352,7 +352,11 @@ if DJANGO_15_PLUS or getattr(settings, 'SF_TEST_TABLE_INSTALLED', False):
 			db_table = 'django_Test__c'
 
 
-	class NoteAttachment(models.Model):
+	# example of relationship from builtin object to custom object
+
+	class Attachment(models.Model):
 		# A standard SFDC object that can have a relationship to any custom object
+		name = models.CharField(max_length=80)
 		parent = models.ForeignKey(Test, sf_read_only=models.NOT_UPDATEABLE, on_delete=models.DO_NOTHING)
-		title = models.CharField(max_length=80)
+		# The "body" of Attachment can't be queried for more rows togehter.
+		body = models.TextField()

--- a/salesforce/testrunner/example/models.py
+++ b/salesforce/testrunner/example/models.py
@@ -192,7 +192,7 @@ class Lead(SalesforceModel):
 	owner = models.ForeignKey(User, on_delete=models.DO_NOTHING,
 			default=models.DEFAULTED_ON_CREATE,
 			related_name='lead_owner_set')
-	last_modified_by = models.ForeignKey(User, on_delete=models.DO_NOTHING,
+	last_modified_by = models.ForeignKey(User, on_delete=models.DO_NOTHING, null=True,
 			sf_read_only=models.READ_ONLY,
 			related_name='lead_lastmodifiedby_set')
 
@@ -290,14 +290,14 @@ class Note(models.Model):
 	parent_type = models.CharField(max_length=50, db_column='Parent.Type', sf_read_only=models.READ_ONLY)
 
 
-class Opportunity(models.Model):
+class Opportunity(SalesforceModel):
 	name = models.CharField(max_length=255)
 	contacts = django.db.models.ManyToManyField(Contact, through='example.OpportunityContactRole', related_name='opportunities')
 	close_date = models.DateField()
 	stage = models.CharField(max_length=255, db_column='StageName') # e.g. "Prospecting"
 
 
-class OpportunityContactRole(models.Model):
+class OpportunityContactRole(SalesforceModel):
 	opportunity = models.ForeignKey(Opportunity, on_delete=models.DO_NOTHING, related_name='contact_roles')
 	contact = models.ForeignKey(Contact, on_delete=models.DO_NOTHING, related_name='opportunity_roles')
 	role = models.CharField(max_length=40, blank=True, null=True)  # e.g. "Business User"

--- a/salesforce/testrunner/example/models.py
+++ b/salesforce/testrunner/example/models.py
@@ -283,22 +283,6 @@ class SalesforceParentModel(SalesforceModel):
 		abstract = True
 
 
-class GeneralCustomModel(SalesforceModel):
-	"""
-	This model is used for tests on a field of type CharField on a custom model
-	specified in local_settings.py:
-	Example:
-		TEST_CUSTOM_FIELD = 'TIMBASURVEYS__SurveyQuestion__c.TIMBASURVEYS__Question__c'
-	Other fields shouldn't be required for saving that object.
-	"""
-	# The line "managed = False" or Meta inherited from SalesforceModel.Meta
-	# is especially important if the model shares a table with other model.
-	class Meta:
-		db_table = test_custom_db_table
-
-	GeneralCustomField = models.CharField(max_length=255, db_column=test_custom_db_column)
-
-
 class Note(models.Model):
 	title = models.CharField(max_length=80)
 	body = models.TextField(null=True)

--- a/salesforce/testrunner/example/models.py
+++ b/salesforce/testrunner/example/models.py
@@ -304,12 +304,12 @@ class OpportunityContactRole(SalesforceModel):
 
 
 class Organization(models.Model):
-    name = models.CharField(max_length=80, sf_read_only=models.NOT_CREATEABLE)
-    division = models.CharField(max_length=80, sf_read_only=models.NOT_CREATEABLE, blank=True)
-    organization_type = models.CharField(max_length=40, verbose_name='Edition',
-    		sf_read_only=models.READ_ONLY) # e.g 'Developer Edition', Enteprise, Unlimited...
-    instance_name = models.CharField(max_length=5, sf_read_only=models.READ_ONLY, blank=True)
-    is_sandbox = models.BooleanField(sf_read_only=models.READ_ONLY)
+	name = models.CharField(max_length=80, sf_read_only=models.NOT_CREATEABLE)
+	division = models.CharField(max_length=80, sf_read_only=models.NOT_CREATEABLE, blank=True)
+	organization_type = models.CharField(max_length=40, verbose_name='Edition',
+			sf_read_only=models.READ_ONLY) # e.g 'Developer Edition', Enteprise, Unlimited...
+	instance_name = models.CharField(max_length=5, sf_read_only=models.READ_ONLY, blank=True)
+	is_sandbox = models.BooleanField(sf_read_only=models.READ_ONLY)
 
 
 # Skipping the model if a custom table isn't installed in your Salesforce
@@ -346,6 +346,7 @@ if DJANGO_15_PLUS or getattr(settings, 'SF_TEST_TABLE_INSTALLED', False):
 		test_text = models.CharField(max_length=40)
 		test_bool = models.BooleanField(default=False)
 		contact = models.ForeignKey(Contact, null=True, on_delete=models.DO_NOTHING)
+
 		class Meta:
 			custom = True
 			db_table = 'django_Test__c'

--- a/salesforce/testrunner/example/models.py
+++ b/salesforce/testrunner/example/models.py
@@ -121,7 +121,7 @@ class Contact(SalesforceModel):
 	# Example that db_column is not necessary for most of fields even with
 	# lower case names and for ForeignKey
 	account = models.ForeignKey(Account, on_delete=models.DO_NOTHING,
-			blank=True, null=True)  # db_column: 'OwnerId'
+			blank=True, null=True)  # db_column: 'AccountId'
 	last_name = models.CharField(max_length=80)
 	first_name = models.CharField(max_length=40, blank=True)
 	name = models.CharField(max_length=121, sf_read_only=models.READ_ONLY,

--- a/salesforce/tests/__init__.py
+++ b/salesforce/tests/__init__.py
@@ -3,5 +3,7 @@
 from salesforce.tests.test_auth import *
 from salesforce.tests.test_integration import *
 from salesforce.tests.test_browser import *
+from salesforce.tests.test_ssl import *
 from salesforce.tests.test_unit import *
 from salesforce.tests.test_utils import *
+

--- a/salesforce/tests/__init__.py
+++ b/salesforce/tests/__init__.py
@@ -1,3 +1,5 @@
+# These imports are necessary only with old Django 1.5.x and older.
+# Nothing common for test sub-modules can be here.
 from salesforce.tests.test_auth import *
 from salesforce.tests.test_integration import *
 from salesforce.tests.test_browser import *

--- a/salesforce/tests/test_auth.py
+++ b/salesforce/tests/test_auth.py
@@ -12,11 +12,7 @@ from salesforce import auth
 from salesforce.backend import sf_alias
 from salesforce.testrunner.example import models
 from salesforce.tests.test_integration import default_is_sf
-try:
-	from unittest import skip, skipUnless
-except ImportError:
-	# old Python 2.6 (Django 1.4 - 1.6 simulated unittest2)
-	from django.utils.unittest import skip, skipUnless
+from .utils import skip, skipUnless
 
 import logging
 log = logging.getLogger(__name__)

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -18,7 +18,7 @@ from django.utils import timezone
 
 from salesforce.testrunner.example.models import (Account, Contact, Lead, User,
 		BusinessHours, ChargentOrder, CronTrigger,
-		Product, Pricebook, PricebookEntry, Note)
+		Product, Pricebook, PricebookEntry, Note, Attachment)
 from salesforce.testrunner.example.models import Test as TestCustomExample
 from salesforce import router, DJANGO_15_PLUS, DJANGO_17_PLUS
 from salesforce.backend import sf_alias
@@ -348,11 +348,14 @@ class BasicSOQLTest(TestCase):
 		results = TestCustomExample.objects.all()[0:1]
 		obj = TestCustomExample(test_text='sf_test')
 		obj.save()
+		attachment = Attachment(name='test attachment', parent=obj)
+		attachment.save()
 		try:
 			results = TestCustomExample.objects.all()[0:1]
 			self.assertEqual(len(results), 1)
 			self.assertEqual(results[0].test_text, 'sf_test')
 		finally:
+			attachment.delete()
 			obj.delete()
 
 	def test_namespaces_auto(self):

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -18,8 +18,7 @@ from django.utils import timezone
 
 from salesforce.testrunner.example.models import (Account, Contact, Lead, User,
 		BusinessHours, ChargentOrder, CronTrigger,
-		Product, Pricebook, PricebookEntry,
-		GeneralCustomModel, Note, test_custom_db_table, test_custom_db_column)
+		Product, Pricebook, PricebookEntry, Note)
 from salesforce.testrunner.example.models import Test as TestCustomExample
 from salesforce import router, DJANGO_15_PLUS, DJANGO_17_PLUS
 from salesforce.backend import sf_alias
@@ -365,23 +364,7 @@ class BasicSOQLTest(TestCase):
 		try:
 			results = TestCustomExample.objects.all()[0:1]
 			self.assertEqual(len(results), 1)
-			self.assertEqual(results[0].test_field, 'sf_test')
-		finally:
-			obj.delete()
-
-	@skipUnless(test_custom_db_table in sf_tables,
-			"Not found the expected custom object '%s'" % test_custom_db_table)
-	def test_custom_object_general(self):
-		"""
-		Create, read and delete any general custom object.
-		Object name and field name are user configurable by TEST_CUSTOM_FIELD.
-		"""
-		obj = GeneralCustomModel(GeneralCustomField='sf_test')
-		obj.save()
-		try:
-			results = GeneralCustomModel.objects.all()[0:1]
-			self.assertEqual(len(results), 1)
-			self.assertEqual(results[0].GeneralCustomField, 'sf_test')
+			self.assertEqual(results[0].test_text, 'sf_test')
 		finally:
 			obj.delete()
 

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -344,15 +344,6 @@ class BasicSOQLTest(TestCase):
 			retrieved_pricebook_entry.delete()
 			product.delete()
 
-	@skipUnless('ChargentOrders__ChargentOrder__c' in sf_tables,
-			'Not found custom tables ChargentOrders__*')
-	def test_custom_objects(self):
-		"""
-		Make sure custom objects work.
-		"""
-		orders = ChargentOrder.objects.all()[0:5]
-		self.assertEqual(len(orders), 5)
-
 	@skipUnless('django_Test__c' in sf_tables, "Not found custom object 'django_Test__c'")
 	def test_simple_custom_object(self):
 		"""

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -23,11 +23,7 @@ from salesforce.testrunner.example.models import Test as TestCustomExample
 from salesforce import router, DJANGO_15_PLUS, DJANGO_17_PLUS
 from salesforce.backend import sf_alias
 import salesforce
-try:
-	from unittest import skip, skipUnless
-except ImportError:
-	# old Python 2.6 (Django 1.4 - 1.6 simulated unittest2)
-	from django.utils.unittest import skip, skipUnless
+from .utils import skip, skipUnless
 
 import logging
 log = logging.getLogger(__name__)

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -737,25 +737,6 @@ class BasicSOQLTest(TestCase):
 	def test_incomplete_raw(self):
 		Contact.objects.raw("select id from Contact")[0].last_name
 
-	@skipUnless(manual_test, "This web service is for manual testing of SSLv3")
-	def test_disabled_sslv3(self):
-		from salesforce.backend.adapter import SslHttpAdapter
-		from requests.adapters import HTTPAdapter
-		import requests
-		# https://zmap.io/sslv3/sslv3test.html
-		url = "https://ssl3.zmap.io/sslv3test.js"
-		# https://www.ssllabs.com/ssltest/viewMyClient.html
-		session = requests.Session()
-		session.mount('https://', SslHttpAdapter())
-		try:
-			response = session.get(url)
-			raise Exception("SSLv3 should be disabled")
-		except requests.exceptions.SSLError:
-			pass
-		session.mount('https://', HTTPAdapter())
-		response = session.get(url)
-		self.assertEqual(response.status_code, 200)
-
 	def test_filter_by_more_fk_to_the_same_model(self):
 		"""
 		Test that aliases are correctly decoded if more relations to

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -67,8 +67,8 @@ class BasicSOQLTest(TestCase):
 		self.objs = []
 		self.test_lead.save()
 		if not default_is_sf:
-			add_obj(Contact(LastName='Test contact 1'))
-			add_obj(Contact(LastName='Test contact 2'))
+			add_obj(Contact(last_name='Test contact 1'))
+			add_obj(Contact(last_name='Test contact 2'))
 			add_obj(User(Username=current_user))
 	
 	def tearDown(self):
@@ -624,7 +624,8 @@ class BasicSOQLTest(TestCase):
 		self.assertIn('first_name', values[0])
 		self.assertNotIn('attributes', values[0])
 		self.assertEqual(len(values[0]), 3)
-		self.assertRegexpMatches(values[0]['pk'], '^003')
+		if default_is_sf:
+			self.assertRegexpMatches(values[0]['pk'], '^003')
 
 		values_list = Contact.objects.values_list('pk', 'first_name', 'last_name')[:2]
 		self.assertEqual(len(values_list), 2)
@@ -707,6 +708,7 @@ class BasicSOQLTest(TestCase):
 	#	# raises "TypeError: list indices must be integers, not str" in resolve_columns
 	#	list(Contact.objects.raw("select Count() from Contact"))
 
+	@skipUnless(default_is_sf, "Default database should be any Salesforce.")
 	def test_only_fields(self):
 		"""Verify that access to "only" fields doesn't require a request, but others do."""
 		request_count_0 = salesforce.backend.query.request_count
@@ -724,6 +726,7 @@ class BasicSOQLTest(TestCase):
 		_ = xx.last_name                                                        # req 5
 		self.assertEqual(salesforce.backend.query.request_count, request_count_0 + 5)
 
+	@skipUnless(default_is_sf, "Default database should be any Salesforce.")
 	def test_defer_fields(self):
 		"""Verify that access to a deferred field requires a new request, but others don't."""
 		request_count_0 = salesforce.backend.query.request_count
@@ -737,6 +740,7 @@ class BasicSOQLTest(TestCase):
 	def test_incomplete_raw(self):
 		Contact.objects.raw("select id from Contact")[0].last_name
 
+	@skipUnless(default_is_sf, "Default database should be any Salesforce.")
 	def test_filter_by_more_fk_to_the_same_model(self):
 		"""
 		Test that aliases are correctly decoded if more relations to

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -626,7 +626,9 @@ class BasicSOQLTest(TestCase):
 		values = Contact.objects.values('pk', 'first_name', 'last_name')[:2]
 		self.assertEqual(len(values), 2)
 		self.assertIn('first_name', values[0])
+		self.assertNotIn('attributes', values[0])
 		self.assertEqual(len(values[0]), 3)
+		self.assertTrue(values[0]['pk'].startswith('003'))
 
 		values_list = Contact.objects.values_list('pk', 'first_name', 'last_name')[:2]
 		self.assertEqual(len(values_list), 2)

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -624,7 +624,7 @@ class BasicSOQLTest(TestCase):
 		self.assertIn('first_name', values[0])
 		self.assertNotIn('attributes', values[0])
 		self.assertEqual(len(values[0]), 3)
-		self.assertTrue(values[0]['pk'].startswith('003'))
+		self.assertRegexpMatches(values[0]['pk'], '^003')
 
 		values_list = Contact.objects.values_list('pk', 'first_name', 'last_name')[:2]
 		self.assertEqual(len(values_list), 2)
@@ -755,8 +755,8 @@ class BasicSOQLTest(TestCase):
 			if not DJANGO_17_PLUS:
 				self.skipTest("Skipped filters with nontrivial relations")
 			# Verify expected filters in SOQL compiled by new Django
-			self.assertTrue('Lead.Owner.Username = %s' in sql)
-			self.assertTrue('Lead.LastModifiedBy.Username = %s' in sql)
+			self.assertIn('Lead.Owner.Username = %s', sql)
+			self.assertIn('Lead.LastModifiedBy.Username = %s', sql)
 			# verify validity for SFDC, verify results
 			refreshed_lead = qs.get()
 			self.assertEqual(refreshed_lead.id, test_lead.id)

--- a/salesforce/tests/test_ssl.py
+++ b/salesforce/tests/test_ssl.py
@@ -1,0 +1,98 @@
+"""no hacks -> we can import immediately
+
+I expect that more services wil disable TLS 1.0 before SFDC and the maintainers of `requests` will fix the issue
+without need to monkey patch long parts of requests code or to repeat hacks like the one criticised in .... issue.
+"""
+from django.conf import settings
+from django.test import TestCase
+from salesforce.backend.adapter import SslHttpAdapter
+from .utils import skip, skipUnless
+import requests
+import ssl
+import sys
+
+# some tests will be run only if they are selected explicitely on the command
+# line "test salesforce.tests.test_ssl.SSLTest..."
+explicitely_selected = 'SslTest' in str(sys.argv)
+
+class SslTest(TestCase):
+	"""
+	The valid results of these tests expect that your "wires" are not under
+	attack at the time you are running tests.
+	"""
+
+	@staticmethod
+	def verify_rejected_ssl(url):
+		"""
+		The utility verifies that the url raises SSLError if the remote server
+		supports only weak ciphers.
+		"""
+		session = requests.Session()
+		session.mount('https://', SslHttpAdapter())
+		try:
+			response = session.get(url)
+			return False
+		except requests.exceptions.SSLError as e:
+			return True
+
+	def test_to_server_without_tls_10(self):
+		"""
+		Verify that connection is possible to SFDC servers that disabled TLS 1.0
+		"""
+		session = requests.Session()
+		session.mount('https://', SslHttpAdapter())
+		try:
+			response = session.get('https://tls1test.salesforce.com')
+			exc = None
+		except requests.exceptions.SSLError as e:
+			exc = e
+		if exc:
+			raise type(exc)(exc.args[0], "Can not connect to server with disabled TLS 1.0")
+		self.assertIn('TLS 1.0 Deactivation Test Passed', response.text)
+
+	def test_under_downgrade_attack_to_ssl_3(self):
+		"""
+		Verify that the connection is rejected if the remote server (or man
+		in the middle) claims that SSLv3 is the best supported protocol.
+		"""
+		# https://zmap.io/sslv3/sslv3test.html
+		url = "https://ssl3.zmap.io/sslv3test.js"
+		if not self.verify_rejected_ssl(url):
+			raise Exception("The protocol SSLv3 should be disabled. see README")
+		if SslHttpAdapter().sf_ssl_version == ssl.PROTOCOL_TLSv1:
+			adapter = SslHttpAdapter(ssl_version=ssl.PROTOCOL_SSLv23)
+			session = requests.Session()
+			session.mount('https://', adapter)
+			try:
+				response = session.get(url)
+				print("It is important to UPGRADE Python and/or SSL before you "
+					"can enable automatic selection of the highest protocol, "
+					"but you must catch both before February 2016. see README")
+			except requests.exceptions.SSLError as e:
+				print("Test passed that you can update settings now to "
+					"\"import ssl; SF_SSL = {'ssl_version': ssl.PROTOCOL_SSLv23}\" "
+					"in order to use new TLS protocols. see README") 
+
+	# all ssllabs tests are from https://www.ssllabs.com/ssltest/viewMyClient.html
+	@skipUnless(explicitely_selected, "these tests can be enabled on command line")
+	def test_protocols_by_ssl_labs(self):
+		session = requests.Session()
+		session.mount('https://', SslHttpAdapter())
+		response = session.get('https://www.ssllabs.com/ssltest/viewMyClient.html')
+		self.assertIn("Your user agent has good protocol support", response.text)
+
+	@skipUnless(explicitely_selected, "these tests can be enabled on command line")
+	def test_vulnerability_logjam_by_ssl_labs(self):
+		if not self.verify_rejected_ssl('https://www.ssllabs.com:10445/'):
+			raise Exception("vulnerable to Logjam Attack")
+		# reported first on May 20, 2015 and usually not fixed yet
+
+	@skipUnless(explicitely_selected, "these tests can be enabled on command line")
+	def test_vulnerability_freak_by_ssl_labs(self):
+		if not self.verify_rejected_ssl('https://www.ssllabs.com:10444/'):
+			raise Exception("vulnerable to FREAK Attack")
+
+	@skipUnless(explicitely_selected, "these tests can be enabled on command line")
+	def test_vulnerability_osx_by_ssl_labs(self):
+		if not self.verify_rejected_ssl('https://www.ssllabs.com:10443/'):
+			raise Exception("iOS and OS X TLS Authentication Vulnerability")

--- a/salesforce/tests/test_ssl.py
+++ b/salesforce/tests/test_ssl.py
@@ -47,7 +47,27 @@ class SslTest(TestCase):
 		except requests.exceptions.SSLError as e:
 			exc = e
 		if exc:
-			raise type(exc)(exc.args[0], "Can not connect to server with disabled TLS 1.0")
+			messages = ["Can not connect to server with disabled TLS 1.0"]
+			response = None
+			if SslHttpAdapter().sf_ssl_version != ssl.PROTOCOL_SSLv23:
+				adapter = SslHttpAdapter(ssl_version=ssl.PROTOCOL_SSLv23)
+				session = requests.Session()
+				session.mount('https://', adapter)
+				try:
+					response = session.get('https://tls1test.salesforce.com')
+				except requests.exceptions.SSLError as e:
+					pass
+			if response:
+				messages.append("This can be fixed by setting "
+					"\"import ssl; SF_SSL = {'ssl_version': ssl.PROTOCOL_SSLv23}\" ")
+				if self.verify_rejected_ssl("https://ssl3.zmap.io/sslv3test.js"):
+					messages.append("The setting should be fixed just now.")
+				else:
+					messages.append("but this would enable the insecure SSLv3 protocol")
+			else:
+				messages.append("The system should be updated to enable newer TLS protocols.")
+			messages.append("see README")
+			raise type(exc)(exc.args[0], '\n' + '\n'.join(messages))
 		self.assertIn('TLS 1.0 Deactivation Test Passed', response.text)
 
 	def test_under_downgrade_attack_to_ssl_3(self):
@@ -58,20 +78,8 @@ class SslTest(TestCase):
 		# https://zmap.io/sslv3/sslv3test.html
 		url = "https://ssl3.zmap.io/sslv3test.js"
 		if not self.verify_rejected_ssl(url):
-			raise Exception("The protocol SSLv3 should be disabled. see README")
-		if SslHttpAdapter().sf_ssl_version == ssl.PROTOCOL_TLSv1:
-			adapter = SslHttpAdapter(ssl_version=ssl.PROTOCOL_SSLv23)
-			session = requests.Session()
-			session.mount('https://', adapter)
-			try:
-				response = session.get(url)
-				print("It is important to UPGRADE Python and/or SSL before you "
-					"can enable automatic selection of the highest protocol, "
-					"but you must catch both before February 2016. see README")
-			except requests.exceptions.SSLError as e:
-				print("Test passed that you can update settings now to "
-					"\"import ssl; SF_SSL = {'ssl_version': ssl.PROTOCOL_SSLv23}\" "
-					"in order to use new TLS protocols. see README") 
+			raise Exception("The protocol SSLv3 should be disabled for better security "
+					"if possible. (It is disabled on all new systems.) see README")
 
 	# all ssllabs tests are from https://www.ssllabs.com/ssltest/viewMyClient.html
 	@skipUnless(explicitely_selected, "these tests can be enabled on command line")

--- a/salesforce/tests/test_ssl.py
+++ b/salesforce/tests/test_ssl.py
@@ -14,6 +14,7 @@ import sys
 # some tests will be run only if they are selected explicitely on the command
 # line "test salesforce.tests.test_ssl.SSLTest..."
 explicitely_selected = 'SslTest' in str(sys.argv)
+skiptest_tls_11 = getattr(settings, 'SF_SSL', {}).get('skiptest_tls_11', False)
 
 class SslTest(TestCase):
 	"""
@@ -35,6 +36,7 @@ class SslTest(TestCase):
 		except requests.exceptions.SSLError as e:
 			return True
 
+	@skipUnless(not skiptest_tls_11, "Skipped due to skiptest_tls_11")
 	def test_to_server_without_tls_10(self):
 		"""
 		Verify that connection is possible to SFDC servers that disabled TLS 1.0

--- a/salesforce/tests/test_utils.py
+++ b/salesforce/tests/test_utils.py
@@ -5,12 +5,7 @@ import unittest
 
 from salesforce.testrunner.example.models import Account, Contact, Lead, Opportunity
 from salesforce.utils import convert_lead
-
-try:
-	from unittest import skip, skipUnless
-except ImportError:
-	# old Python 2.6 (Django 1.4 - 1.6 simulated unittest2)
-	from django.utils.unittest import skip, skipUnless
+from .utils import skip, skipUnless
 try:
     import beatbox
 except ImportError:

--- a/salesforce/tests/utils.py
+++ b/salesforce/tests/utils.py
@@ -1,0 +1,6 @@
+"Utilities useful for tests"
+try:
+	from unittest import skip, skipUnless
+except ImportError:
+	# old Python 2.6 (Django 1.4 - 1.6 simulated unittest2)
+	from django.utils.unittest import skip, skipUnless

--- a/tests/inspectdb/slow_test.py
+++ b/tests/inspectdb/slow_test.py
@@ -36,7 +36,7 @@ def run():
 	for tab in sf.introspection.table_list_cache['sobjects']:
 		if tab['retrieveable'] and not tab['name'] in (
 				# These require specific filters (descried in their error messages)
-				'CollaborationGroupRecord',
+				'CollaborationGroupRecord', 'ContentFolderMember',
 				'ContentDocumentLink', 'Idea', 'IdeaComment', 'UserProfileFeed',
 				'Vote', #'OpportunityPartner', 'Product2Feed',
 				# UNKNOWN_EXCEPTION:

--- a/tox.ini
+++ b/tox.ini
@@ -47,16 +47,19 @@ basepython=python2.7.10
 deps =
     {[testenv]deps}
     Django==1.7
+    # some configurations are with beatbox
+    beatbox
 [testenv:py27dj18]
 deps =
     {[testenv]deps}
-    Django==1.8
+    Django==1.8.3
     #https://www.djangoproject.com/download/1.8a1/tarball/
 [testenv:py33dj17]
 basepython = python3.3
 deps =
     {[testenv]deps}
     Django==1.7.3
+    beatbox
     coverage
 [testenv:py34dj16]
 basepython = python3.4


### PR DESCRIPTION
Much documentation together with code

If the test of TLS 1.1+ fails and no upgrade is possible, it can be skipped by
settings.py

       SF_SSL = {'skiptest_tls_11': True, ...}

