### PR TITLE
Set SSLv23 for Travis builds only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - "pip install -r requirements.txt"
   - "pip install ."
 script:
-  - echo -e "import ssl\nSF_SSL = {'ssl_version': ssl.PROTOCOL_SSLv23}" > salesforce/testrunner/local_settings.py
+  - echo -e "import ssl\nSF_SSL = dict(ssl_version=ssl.PROTOCOL_SSLv23)" > salesforce/testrunner/local_settings.py
   - python manage.py syncdb --noinput
   - bash tests/inspectdb/test.sh
   - bash tests/tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
   - "pip install -r requirements.txt"
   - "pip install ."
 script:
+  - echo -e "import ssl\nSF_SSL = {'ssl_version': ssl.PROTOCOL_SSLv23}" > salesforce/testrunner/local_settings.py
   - python manage.py syncdb --noinput
   - bash tests/inspectdb/test.sh
   - bash tests/tests.sh

--- a/salesforce/testrunner/settings.py
+++ b/salesforce/testrunner/settings.py
@@ -8,9 +8,6 @@ ADMINS = (
 	# ('Your Name', 'your_email@example.com'),
 )
 
-import ssl
-SF_SSL = {'ssl_version': ssl.PROTOCOL_SSLv23}
-
 PERSON_ACCOUNT_ACTIVATED = False
 
 DATABASES = {


### PR DESCRIPTION
This writes a local_settings.py file to setup sslv23 rather than install PyOpenSSL, as Travis is currently running Python 2.7.9 for its build.