### PR TITLE
Run tox on the Travis build, to test multiple Python/Django versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 sudo: false
 language: python
-python:
-  # - "2.6"
-  - "2.7"
-  # - "3.3"
 env:
   global:
     - secure: "Z6wS6a/YcyT8w5l+2HfMItbn2mbv+f1W43WixoqB4QkgiocjBWvmAQD6PN1sEgWVmZlRvWCABK8FcGG+Y6RPFeNdCE0U1h9hEgOiAnhUpWWH/AhOYDZ0PnFwA3/iRrHS2VFPmhdkjw1BUEfqXaJfDYtlZLgpMMfRvEjIJ8Uqq6M="
@@ -13,11 +9,11 @@ env:
 before_install:
  - "pip install setuptools_git"
 install:
-  - "pip install -U pip"
+  - "pyenv install 2.6"
+  - "pyenv install 2.7"
+  - "pyenv install 3.3"
+  - "pyenv rehash"
   - "pip install tox"
-  - "pip install -r requirements.txt"
-  - "pip install ."
 script:
   - echo -e "import ssl\nSF_SSL = dict(ssl_version=ssl.PROTOCOL_SSLv23)" > salesforce/testrunner/local_settings.py
-  - python manage.py syncdb --noinput
-  - tox py27dj17
+  - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,19 @@
 sudo: false
 language: python
-python:
-  # - "2.6"
-  - "2.7"
-  # - "3.3"
 env:
   global:
     - secure: "Z6wS6a/YcyT8w5l+2HfMItbn2mbv+f1W43WixoqB4QkgiocjBWvmAQD6PN1sEgWVmZlRvWCABK8FcGG+Y6RPFeNdCE0U1h9hEgOiAnhUpWWH/AhOYDZ0PnFwA3/iRrHS2VFPmhdkjw1BUEfqXaJfDYtlZLgpMMfRvEjIJ8Uqq6M="
     - secure: "JJGGbExBKyXkAltrc4rRLG56ks20/GfGcfugI9mqjeHgQ7IcDvhnouqAIjfbNlhgclyAkWHwJRs7taaM0T9a9AcEQujs2B0JJYOLQSBGnWJSCbsDspWAdlT92U+PzhnZrDm7apg1iBk/c8KtofBo6DqsTveBocFnYXTjeqbSVuY="
     - secure: "TrsYtntXQWgjrXPFaL3aUPoyPtR7pBVqsRx5dIj0yhrPuZR0L2bFi0MOA8cXflaYucx+xa+PEyrPO6FfLl+ri8I2WiXeDLbXlUC614UW6Od1kCklZ7/gk5wor7RwfEtIAtxh5erljUw2N2O9utkRFBDCuASRaQCqBzMItgcUOhA="
     - secure: "IIcUd3p7k0RFZJW9b+t5NRATvoS3kERIWBTQoE2LkFRaMFbwAJ/CMFxnGzF7whwEGqgWDtDiILYj9KHchiUMw85A+qEXDlwk60hVJyVJzqm5jyPewV19WK4JRo/21BrwNErvJm6echWHtfboHEWxHousVH7uyrujrK4ULDWZRnc="
-  matrix:
-    # - DJANGO_VERSION=1.4.10
-    # - DJANGO_VERSION=1.5.5
-    - DJANGO_VERSION=1.7.7
-matrix:
-  exclude:
-    - python: "3.3"
-      env: DJANGO_VERSION=1.4.10
 before_install:
  - "pip install setuptools_git"
 install:
-  - "pip install Django==$DJANGO_VERSION"
+  - "pip install -U pip"
+  - "pip install tox"
   - "pip install -r requirements.txt"
   - "pip install ."
 script:
   - echo -e "import ssl\nSF_SSL = dict(ssl_version=ssl.PROTOCOL_SSLv23)" > salesforce/testrunner/local_settings.py
   - python manage.py syncdb --noinput
-  - bash tests/inspectdb/test.sh
-  - bash tests/tests.sh
-  - python manage.py test salesforce
+  - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
 install:
   - "git clone https://github.com/yyuu/pyenv.git ~/.pyenv"
   - "eval \"$(pyenv init -)\""
-  - "pyenv install 2.6"
-  - "pyenv install 2.7"
+  - "pyenv install 2.6.9"
+  - "pyenv install 2.7.9"
   - "pyenv install 3.3"
   - "pyenv rehash"
   - "pip install tox"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 sudo: false
 language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.3"
 env:
   global:
     - secure: "Z6wS6a/YcyT8w5l+2HfMItbn2mbv+f1W43WixoqB4QkgiocjBWvmAQD6PN1sEgWVmZlRvWCABK8FcGG+Y6RPFeNdCE0U1h9hEgOiAnhUpWWH/AhOYDZ0PnFwA3/iRrHS2VFPmhdkjw1BUEfqXaJfDYtlZLgpMMfRvEjIJ8Uqq6M="

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,11 @@ env:
     - secure: "JJGGbExBKyXkAltrc4rRLG56ks20/GfGcfugI9mqjeHgQ7IcDvhnouqAIjfbNlhgclyAkWHwJRs7taaM0T9a9AcEQujs2B0JJYOLQSBGnWJSCbsDspWAdlT92U+PzhnZrDm7apg1iBk/c8KtofBo6DqsTveBocFnYXTjeqbSVuY="
     - secure: "TrsYtntXQWgjrXPFaL3aUPoyPtR7pBVqsRx5dIj0yhrPuZR0L2bFi0MOA8cXflaYucx+xa+PEyrPO6FfLl+ri8I2WiXeDLbXlUC614UW6Od1kCklZ7/gk5wor7RwfEtIAtxh5erljUw2N2O9utkRFBDCuASRaQCqBzMItgcUOhA="
     - secure: "IIcUd3p7k0RFZJW9b+t5NRATvoS3kERIWBTQoE2LkFRaMFbwAJ/CMFxnGzF7whwEGqgWDtDiILYj9KHchiUMw85A+qEXDlwk60hVJyVJzqm5jyPewV19WK4JRo/21BrwNErvJm6echWHtfboHEWxHousVH7uyrujrK4ULDWZRnc="
-before_install:
- - "pip install setuptools_git"
+    - PYENV_ROOT="$HOME/.pyenv"
+    - PATH="$PYENV_ROOT/bin:$PATH"
 install:
+  - "git clone https://github.com/yyuu/pyenv.git ~/.pyenv"
+  - "eval \"$(pyenv init -)\""
   - "pyenv install 2.6"
   - "pyenv install 2.7"
   - "pyenv install 3.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: python
 python:
-  - "2.6"
+  # - "2.6"
   - "2.7"
-  - "3.3"
+  # - "3.3"
 env:
   global:
     - secure: "Z6wS6a/YcyT8w5l+2HfMItbn2mbv+f1W43WixoqB4QkgiocjBWvmAQD6PN1sEgWVmZlRvWCABK8FcGG+Y6RPFeNdCE0U1h9hEgOiAnhUpWWH/AhOYDZ0PnFwA3/iRrHS2VFPmhdkjw1BUEfqXaJfDYtlZLgpMMfRvEjIJ8Uqq6M="
@@ -20,4 +20,4 @@ install:
 script:
   - echo -e "import ssl\nSF_SSL = dict(ssl_version=ssl.PROTOCOL_SSLv23)" > salesforce/testrunner/local_settings.py
   - python manage.py syncdb --noinput
-  - tox
+  - tox py27dj17

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,12 @@ install:
   - "eval \"$(pyenv init -)\""
   - "pyenv install 2.6.9"
   - "pyenv install 2.7.9"
-  - "pyenv install 3.3"
+  - "pyenv install 3.3.6"
   - "pyenv rehash"
   - "pip install tox"
+cache:
+  directories:
+  - $HOME/.pyenv
 script:
   - echo -e "import ssl\nSF_SSL = dict(ssl_version=ssl.PROTOCOL_SSLv23)" > salesforce/testrunner/local_settings.py
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     - PYENV_ROOT="$HOME/.pyenv"
     - PATH="$PYENV_ROOT/bin:$PATH"
 install:
-  - "git clone https://github.com/yyuu/pyenv.git ~/.pyenv"
+  - "test -d ~/.pyenv || git clone https://github.com/yyuu/pyenv.git ~/.pyenv"
   - "eval \"$(pyenv init -)\""
   - "pyenv install 2.6.9"
   - "pyenv install 2.7.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - "git clone https://github.com/yyuu/pyenv.git ~/.pyenv"
   - "eval \"$(pyenv init -)\""
   - "pyenv install 2.6.9"
-  - "pyenv install 2.7.9"
+  - "pyenv install 2.7.10"
   - "pyenv install 3.3.6"
   - "pyenv rehash"
   - "pip install tox"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ env:
 install:
   - "test -d ~/.pyenv || git clone https://github.com/yyuu/pyenv.git ~/.pyenv"
   - "eval \"$(pyenv init -)\""
-  - "pyenv install 2.6.9"
-  - "pyenv install 2.7.10"
-  - "pyenv install 3.3.6"
+  - "test -d ~/.pyenv/versions/2.6.9 || pyenv install 2.6.9"
+  - "test -d ~/.pyenv/versions/2.7.10 || pyenv install 2.7.10"
+  - "test -d ~/.pyenv/versions/3.3.6 || pyenv install 3.3.6"
   - "pyenv rehash"
   - "pip install tox"
 cache:


### PR DESCRIPTION
We've been running tox internally for some time, but I don't think there's any reason I couldn't get it running on Travis. We can't use the built-in multi-environment support from Travis because it tries to run them all in parallel, which isn't currently supported by our tests if they're using the same account.

This pull request isn't ready for merge yet, but I have a feeling I may have some questions for @hynekcer and this will be a good place for discussion.

Incidentally, the reason this is on a branch on the main repo instead of on my personal fork is because the encrypted environment variables in the .travis.yml file are essentially keyed to this repo, so only pushes from the repo will be able to access the demo Salesforce account I use to test.