### PR TITLE
add none() method to SalesforceManager

### DIFF
--- a/salesforce/backend/manager.py
+++ b/salesforce/backend/manager.py
@@ -64,3 +64,6 @@ class SalesforceManager(manager.Manager):
 			return self.get_queryset().query_all()
 		else:
 			return self.get_queryset()
+
+	def none(self):
+		return super(SalesforceManager, self).get_queryset().none()


### PR DESCRIPTION
Prior to this patch, if you ran the none method on a salesforce model, it returned a salesforce error.  

i.e. Lead.objects.none() returned a salesforce error.

The salesforce error returned is:

salesforce.backend.base.SalesforceError
salesforce.backend.base.SalesforceError: SOQL statements cannot be empty or null

This permits you to use the none() method on salesforce models.

This is my first pull request to a public repo ever, so apologies in advance.