### PR TITLE
Fixed EmptyResultSet error after none() method in queryset. Closes #124

### DIFF
--- a/salesforce/backend/query.py
+++ b/salesforce/backend/query.py
@@ -17,6 +17,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import connections
 from django.db.models import query, Count
 from django.db.models.sql import Query, RawQuery, constants, subqueries
+from django.db.models.sql.datastructures import EmptyResultSet
 from django.db.models.query_utils import deferred_class_factory
 from django.utils.encoding import force_text
 from django.utils.six import PY3
@@ -247,7 +248,10 @@ class SalesforceQuerySet(query.QuerySet):
 		An iterator over the results from applying this QuerySet to the
 		remote web service.
 		"""
-		sql, params = compiler.SQLCompiler(self.query, connections[self.db], None).as_sql()
+		try:
+			sql, params = compiler.SQLCompiler(self.query, connections[self.db], None).as_sql()
+		except EmptyResultSet:
+			raise StopIteration
 		cursor = CursorWrapper(connections[self.db], self.query)
 		cursor.execute(sql, params)
 

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -710,11 +710,12 @@ class BasicSOQLTest(TestCase):
 			test_lead.delete()
 
 	def test_none_method_queryset(self):
-		"""Test that none() method in the queryset return [], not error"""
+		"""Test that none() method in the queryset returns [], not error"""
 		request_count_0 = salesforce.backend.query.request_count
 		self.assertEqual(tuple(Contact.objects.none()), ())
 		self.assertEqual(tuple(Contact.objects.all().none().all()), ())
 		self.assertEqual(repr(Contact.objects.none()), '[]')
 		self.assertEqual(salesforce.backend.query.request_count, request_count_0,
 				"Do database requests should be done with .none() method")
+
 	#@skip("Waiting for bug fix")

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -709,4 +709,12 @@ class BasicSOQLTest(TestCase):
 		finally:
 			test_lead.delete()
 
+	def test_none_method_queryset(self):
+		"""Test that none() method in the queryset return [], not error"""
+		request_count_0 = salesforce.backend.query.request_count
+		self.assertEqual(tuple(Contact.objects.none()), ())
+		self.assertEqual(tuple(Contact.objects.all().none().all()), ())
+		self.assertEqual(repr(Contact.objects.none()), '[]')
+		self.assertEqual(salesforce.backend.query.request_count, request_count_0,
+				"Do database requests should be done with .none() method")
 	#@skip("Waiting for bug fix")


### PR DESCRIPTION
The patch in "SalesforceQuerySet.iterator" imitates
 "django.db.models.sql.compiler.SQLCompiler" that does the same for normal
backends, but in 1 method instead of 3 nested layers.
We have no more similar hooks for this (in Django 1.8):

  django/db/models/query.py(254) QuerySet.iterator()
-> for row in compiler.results_iter():
  django/db/models/sql/compiler.py(783) SQLCompiler.results_iter()
-> for rows in self.execute_sql(MULTI):
> django/db/models/sql/compiler.py(821) SQLCompiler.execute_sql()
  except EmptyResultSet: