### PR TITLE
Many2many relationship, advanced Where conditions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -171,8 +171,8 @@ Advanced usage
    
    One way to speed this up is to change the SALESFORCE_DB_ALIAS to point to
    another DB connection (preferably SQLite) during testing using the
-   ``TEST_*`` settings variables. The only outbound connections will then be to
-   the authentication servers.
+   ``TEST_*`` settings variables. Django unit tests without SalesforceModel
+   are fast everytimes.
    
 -  **Multiple SFDC connections** - In most cases, a single connection is all
    that most apps require, so the default DB connection to use for Salesforce

--- a/salesforce/auth.py
+++ b/salesforce/auth.py
@@ -35,8 +35,9 @@ def authenticate(db_alias=None, settings_dict=None):
 	
 		Params:
 			db_alias:  The database alias e.g. the default SF alias 'salesforce'.
-			settings_dict: Should be obtained from django.conf.DATABASES['salesforce'].
-				   It is only important for the first connection.
+			settings_dict: It is only important for the first connection.
+					Should be taken from django.conf.DATABASES['salesforce'],
+					because it is not known in connection.settings_dict initially.
 
 	This function can be called multiple times, but will only make
 	an external request once per the lifetime of the auth token. Subsequent

--- a/salesforce/backend/__init__.py
+++ b/salesforce/backend/__init__.py
@@ -31,7 +31,8 @@ MAX_RETRIES = getattr(settings, 'REQUESTS_MAX_RETRIES', 1)
 
 
 def getaddrinfo_wrapper(host, port, family=socket.AF_INET, socktype=0, proto=0, flags=0):
-	    return orig_getaddrinfo(host, port, family, socktype, proto, flags)
+	"""Patched 'getaddrinfo' with default family IPv4 (enabled by settings IPV4_ONLY=True)"""
+	return orig_getaddrinfo(host, port, family, socktype, proto, flags)
 
 # patch to IPv4 if required and not patched by anything other yet
 if getattr(settings, 'IPV4_ONLY', False) and socket.getaddrinfo.__module__ in ('socket', '_socket'):

--- a/salesforce/backend/base.py
+++ b/salesforce/backend/base.py
@@ -11,6 +11,7 @@ Salesforce database backend for Django.
 
 import logging
 import requests
+import sys
 import threading
 
 from salesforce import DJANGO_16_PLUS, DJANGO_18_PLUS
@@ -122,7 +123,9 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 		self.introspection = DatabaseIntrospection(self)
 		self.validation = DatabaseValidation(self)
 		self._sf_session = None
-		if not getattr(settings, 'SF_LAZY_CONNECT', False):
+		# The SFDC database is connected as late as possible if only tests
+		# are running. Some tests don't require a connection.
+		if not getattr(settings, 'SF_LAZY_CONNECT', 'test' in sys.argv):
 			self.make_session()
 
 	def make_session(self):

--- a/salesforce/backend/query.py
+++ b/salesforce/backend/query.py
@@ -167,6 +167,10 @@ def prep_for_deserialize(model, record, using, init_list=None):
 	else:
 		raise ImproperlyConfigured("Can't discover the app_label for %s, you must specify it via model meta options.")
 
+	if len(record.keys()) == 1 and model._meta.db_table in record:
+		while len(record) == 1:
+			record = record.values()[0]
+
 	fields = dict()
 	for x in model._meta.fields:
 		if not x.primary_key and (not init_list or x.name in init_list):

--- a/salesforce/backend/query.py
+++ b/salesforce/backend/query.py
@@ -169,7 +169,7 @@ def prep_for_deserialize(model, record, using, init_list=None):
 
 	if len(record.keys()) == 1 and model._meta.db_table in record:
 		while len(record) == 1:
-			record = record.values()[0]
+			record = list(record.values())[0]
 
 	fields = dict()
 	for x in model._meta.fields:

--- a/salesforce/backend/query.py
+++ b/salesforce/backend/query.py
@@ -17,6 +17,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import connections
 from django.db.models import query, Count
 from django.db.models.sql import Query, RawQuery, constants, subqueries
+from django.db.models.sql.datastructures import EmptyResultSet
 from django.db.models.query_utils import deferred_class_factory
 from django.utils.encoding import force_text
 from django.utils.six import PY3
@@ -247,7 +248,10 @@ class SalesforceQuerySet(query.QuerySet):
 		An iterator over the results from applying this QuerySet to the
 		remote web service.
 		"""
-		sql, params = compiler.SQLCompiler(self.query, connections[self.db], None).as_sql()
+		try:
+			sql, params = compiler.SQLCompiler(self.query, connections[self.db], None).as_sql()
+		except EmptyResultSet:
+			raise StopIteration
 		cursor = CursorWrapper(connections[self.db], self.query)
 		cursor.execute(sql, params)
 

--- a/salesforce/backend/query.py
+++ b/salesforce/backend/query.py
@@ -228,7 +228,7 @@ def extract_values(query):
 			assert len(query.objs) == 1, "bulk_create is not supported by Salesforce REST API"
 			value = getattr(query.objs[0], field.attname)
 			# The 'DEFAULT' is a backward compatibility name.
-			if isinstance(field, models.ForeignKey) and value in ('DEFAULT', 'DEFAULTED_ON_CREATE'):
+			if isinstance(field, (models.ForeignKey, models.BooleanField)) and value in ('DEFAULT', 'DEFAULTED_ON_CREATE'):
 				continue
 			if isinstance(value, models.DefaultedOnCreate):
 				continue

--- a/salesforce/backend/subselect.py
+++ b/salesforce/backend/subselect.py
@@ -1,0 +1,59 @@
+import re
+from unittest import TestCase
+
+def find_closing_parenthesis(sql, startpos):
+	"""Find the pair of opening and closing parentheses.
+
+	Starts search at the position startpos.
+	Returns tuple of positions (opening, closing) if search succeeds, otherwise None.
+	"""
+	pattern = re.compile(r'[()]')
+	level = 0
+	opening = 0
+	for match in pattern.finditer(sql, startpos):
+		par = match.group()
+		if par == '(':
+			if level == 0:
+				opening = match.start()
+			level += 1
+		if par == ')':
+			assert level > 0
+			level -= 1
+			if level == 0:
+				closing = match.end()
+				return opening, closing
+
+def transform_except_subselect(sql, func):
+	"""Call a func on every part of SOQL query except nested (SELECT ...)"""
+	start = 0
+	out = []
+	while sql.find('(SELECT', start) > -1:
+		pos = sql.find('(SELECT', start)
+		out.append(func(sql[start:pos]))
+		start, pos = find_closing_parenthesis(sql, pos)
+		out.append(sql[start:pos])
+		start = pos
+	out.append(func(sql[start:len(sql)]))
+	return ''.join(out)
+
+
+class TestSubSelectSearch(TestCase):
+	def test_parenthesis(self):
+		self.assertEqual(find_closing_parenthesis('() (() (())) ()', 0), (0, 2))
+		self.assertEqual(find_closing_parenthesis('() (() (())) ()', 2), (3, 12))
+		self.assertEqual(find_closing_parenthesis('() (() (())) ()', 3), (3, 12))
+		self.assertEqual(find_closing_parenthesis('() (() (())) ()', 6), (7, 11))
+		self.assertEqual(find_closing_parenthesis('() (() (())) ()',13), (13,15))
+		self.assertRaises(AssertionError, find_closing_parenthesis, '() (() (())) ()',1)
+
+	def test_subselect(self):
+		sql = "SELECT a, (SELECT x FROM y) FROM b WHERE (c IN (SELECT p FROM q WHERE r = %s) AND c = %s)"
+		func = lambda sql: '*transfomed*'
+		expected =  "*transfomed*(SELECT x FROM y)*transfomed*(SELECT p FROM q WHERE r = %s)*transfomed*"
+		self.assertEqual(transform_except_subselect(sql, func), expected)
+
+	def test_nested_subselect(self):
+		sql = "SELECT a, (SELECT x, (SELECT p FROM q) FROM y) FROM b"
+		func = lambda x: '*transfomed*'
+		expected =  "*transfomed*(SELECT x, (SELECT p FROM q) FROM y)*transfomed*"
+		self.assertEqual(transform_except_subselect(sql, func), expected)

--- a/salesforce/testrunner/example/models.py
+++ b/salesforce/testrunner/example/models.py
@@ -195,6 +195,8 @@ class Lead(SalesforceModel):
 	last_modified_by = models.ForeignKey(User, on_delete=models.DO_NOTHING, null=True,
 			sf_read_only=models.READ_ONLY,
 			related_name='lead_lastmodifiedby_set')
+	is_converted = models.BooleanField(verbose_name='Converted',
+			sf_read_only=models.NOT_UPDATEABLE, default=models.DEFAULTED_ON_CREATE)
 
 	def __str__(self):
 		return self.Name
@@ -360,3 +362,8 @@ if DJANGO_15_PLUS or getattr(settings, 'SF_TEST_TABLE_INSTALLED', False):
 		parent = models.ForeignKey(Test, sf_read_only=models.NOT_UPDATEABLE, on_delete=models.DO_NOTHING)
 		# The "body" of Attachment can't be queried for more rows togehter.
 		body = models.TextField()
+
+
+	class Task(models.Model):
+		who = models.ForeignKey(Lead, on_delete=models.DO_NOTHING, blank=True, null=True)  # Reference to tables [Contact, Lead]
+		what = models.ForeignKey(Account, related_name='task_what_set', on_delete=models.DO_NOTHING, blank=True, null=True)  # Refer

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -21,7 +21,7 @@ from salesforce.testrunner.example.models import (Account, Contact, Lead, User,
 		Opportunity, OpportunityContactRole,
 		Product, Pricebook, PricebookEntry, Note, Attachment)
 from salesforce.testrunner.example.models import Test as TestCustomExample
-from salesforce import router, DJANGO_15_PLUS, DJANGO_16_PLUS
+from salesforce import router, DJANGO_15_PLUS
 from salesforce.backend import sf_alias
 import salesforce
 from .utils import skip, skipUnless
@@ -640,7 +640,6 @@ class BasicSOQLRoTest(TestCase):
 			oc.delete()
 			oppo.delete()
 
-	#@skipUnless(DJANGO_16_PLUS, "Subqueries on Salesforce require Django 1.6+ for compiler")
 	def test_subquery_condition(self):
 		"""Regression test with a filter based on subquery.
 

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -41,14 +41,16 @@ default_is_sf = router.is_sf_database(sf_alias)
 manual_test = False  # skipped by automated tests
 
 def refresh(obj):
-	"""Get the same object refreshed from the same db."""
+	"""Get the same object refreshed from the same db.
+	"""
 	db = obj._state.db
 	return type(obj).objects.using(db).get(pk=obj.pk)
 	
 
 class BasicSOQLTest(TestCase):
 	def setUp(self):
-		"""Create our test lead record."""
+		"""Create our test lead record.
+		"""
 		def add_obj(obj):
 			obj.save()
 			self.objs.append(obj)
@@ -68,7 +70,8 @@ class BasicSOQLTest(TestCase):
 			add_obj(User(Username=current_user))
 	
 	def tearDown(self):
-		"""Clean up our test records."""
+		"""Clean up our test records.
+		"""
 		if self.test_lead.pk is not None:
 			self.test_lead.delete()
 		for obj in self.objs:
@@ -93,7 +96,8 @@ class BasicSOQLTest(TestCase):
 
 	@skipUnless(default_is_sf, "Default database should be any Salesforce.")
 	def test_raw_foreignkey_id(self):
-		"""Get the first two contacts by raw query with a ForeignKey id field."""
+		"""Get the first two contacts by raw query with a ForeignKey id field.
+		"""
 		contacts = Contact.objects.raw(
 				"SELECT Id, LastName, FirstName, OwnerId FROM Contact "
 				"LIMIT 2")
@@ -102,12 +106,14 @@ class BasicSOQLTest(TestCase):
 		self.assertIn('@', contacts[0].owner.Email)
 
 	def test_select_all(self):
-		"""Get the first two contact records."""
+		"""Get the first two contact records.
+		"""
 		contacts = Contact.objects.all()[0:2]
 		self.assertEqual(len(contacts), 2)
 
 	def test_exclude_query_construction(self):
-		"""Test that exclude query construction returns valid SOQL."""
+		"""Test that exclude query construction returns valid SOQL.
+		"""
 		contacts = Contact.objects.filter(first_name__isnull=False).exclude(email="steve@apple.com", last_name="Wozniak").exclude(last_name="smith")
 		number_of_contacts = contacts.count()
 		self.assertIsInstance(number_of_contacts, int)
@@ -117,7 +123,8 @@ class BasicSOQLTest(TestCase):
 
 	@skipUnless(default_is_sf, "Default database should be any Salesforce.")
 	def test_foreign_key(self):
-		"""Verify that the owner of an Contact is the currently logged admin."""
+		"""Verify that the owner of an Contact is the currently logged admin.
+		"""
 		current_sf_user = User.objects.get(Username=current_user)
 		test_contact = Contact(first_name = 'sf_test', last_name='my')
 		test_contact.save()
@@ -130,7 +137,8 @@ class BasicSOQLTest(TestCase):
 			test_contact.delete()
 
 	def test_foreign_key_column(self):
-		"""Verify filtering by a column of related parent object."""
+		"""Verify filtering by a column of related parent object.
+		"""
 		test_account = Account(Name = 'sf_test account')
 		test_account.save()
 		test_contact = Contact(first_name = 'sf_test', last_name='my', account=test_account)
@@ -143,7 +151,8 @@ class BasicSOQLTest(TestCase):
 			test_account.delete()
 
 	def test_update_date(self):
-		"""Test updating a date."""
+		"""Test updating a date.
+		"""
 		now = timezone.now().replace(microsecond=0)
 		contact = Contact(first_name = 'sf_test', last_name='my')
 		contact.save()
@@ -156,7 +165,8 @@ class BasicSOQLTest(TestCase):
 			contact.delete()
 	
 	def test_insert_date(self):
-		"""Test inserting a date."""
+		"""Test inserting a date.
+		"""
 		now = timezone.now().replace(microsecond=0)
 		contact = Contact(
 				first_name = 'Joe',
@@ -195,7 +205,8 @@ class BasicSOQLTest(TestCase):
 			contact.delete()
 	
 	def test_get(self):
-		"""Get the test lead record."""
+		"""Get the test lead record.
+		"""
 		lead = Lead.objects.get(Email=test_email)
 		self.assertEqual(lead.FirstName, 'User')
 		self.assertEqual(lead.LastName, 'Unittest General')
@@ -205,7 +216,8 @@ class BasicSOQLTest(TestCase):
 		self.assertEqual(lead.Name, 'User Unittest General')
 	
 	def test_not_null(self):
-		"""Get the test lead record by isnull condition."""
+		"""Get the test lead record by isnull condition.
+		"""
 		lead = Lead.objects.get(Email__isnull=False, FirstName='User')
 		self.assertEqual(lead.FirstName, 'User')
 		self.assertEqual(lead.LastName, 'Unittest General')
@@ -226,7 +238,8 @@ class BasicSOQLTest(TestCase):
 			test_contact.delete()
 	
 	def test_unicode(self):
-		"""Make sure weird unicode breaks properly."""
+		"""Make sure weird unicode breaks properly.
+		"""
 		test_lead = Lead(FirstName=u'\u2603', LastName="Unittest Unicode",
 				Email='test-djsf-unicode-email@example.com',
 				Company="Some company")
@@ -237,7 +250,8 @@ class BasicSOQLTest(TestCase):
 			test_lead.delete()
 	
 	def test_date_comparison(self):
-		"""Test that date comparisons work properly."""
+		"""Test that date comparisons work properly.
+		"""
 		today = datetime.datetime(2013, 8, 27)
 		if settings.USE_TZ:
 			today = timezone.make_aware(today, pytz.utc)
@@ -256,7 +270,8 @@ class BasicSOQLTest(TestCase):
 	
 	@skipUnless(default_is_sf, "Default database should be any Salesforce.")
 	def test_insert(self):
-		"""Create a lead record, and make sure it ends up with a valid Salesforce ID."""
+		"""Create a lead record, and make sure it ends up with a valid Salesforce ID.
+		"""
 		test_lead = Lead(FirstName="User", LastName="Unittest Inserts",
 				Email='test-djsf-inserts-email@example.com',
 				Company="Some company")
@@ -267,7 +282,8 @@ class BasicSOQLTest(TestCase):
 			test_lead.delete()
 	
 	def test_delete(self):
-		"""Create a lead record, then delete it, and make sure it's gone."""
+		"""Create a lead record, then delete it, and make sure it's gone.
+		"""
 		test_lead = Lead(FirstName="User", LastName="Unittest Deletes",
 				Email='test-djsf-delete-email@example.com',
 				Company="Some company")
@@ -277,7 +293,8 @@ class BasicSOQLTest(TestCase):
 		self.assertRaises(Lead.DoesNotExist, Lead.objects.get, Email='test-djsf-delete-email@example.com')
 	
 	def test_update(self):
-		"""Update the test lead record."""
+		"""Update the test lead record.
+		"""
 		test_lead = Lead.objects.get(Email=test_email)
 		self.assertEqual(test_lead.FirstName, 'User')
 		test_lead.FirstName = 'Tested'
@@ -286,7 +303,8 @@ class BasicSOQLTest(TestCase):
 
 	@skipUnless(default_is_sf, "Default database should be any Salesforce.")
 	def test_decimal_precision(self):
-		"""Verify the same precision of saved and retrived DecimalField"""
+		"""Verify the same precision of saved and retrived DecimalField
+		"""
 		product = Product(Name="Test Product")
 		product.save()
 
@@ -305,7 +323,8 @@ class BasicSOQLTest(TestCase):
 
 	@skipUnless('django_Test__c' in sf_tables, "Not found custom object 'django_Test__c'")
 	def test_simple_custom_object(self):
-		"""Create, read and delete a simple custom object `django_Test__c`."""
+		"""Create, read and delete a simple custom object `django_Test__c`.
+		"""
 		results = TestCustomExample.objects.all()[0:1]
 		obj = TestCustomExample(test_text='sf_test')
 		obj.save()
@@ -330,7 +349,8 @@ class BasicSOQLTest(TestCase):
 		self.assertEqual(tested_field.column, 'ChargentOrders__Balance_Due__c')
 
 	def test_datetime_miliseconds(self):
-		"""Verify that a field with milisecond resolution is readable."""
+		"""Verify that a field with milisecond resolution is readable.
+		"""
 		triggers = CronTrigger.objects.all()
 		if not triggers:
 			self.skipTest("No object with milisecond resolution found.")
@@ -340,7 +360,8 @@ class BasicSOQLTest(TestCase):
 
 	@skipUnless(default_is_sf, "Default database should be any Salesforce.")
 	def test_time_field(self):
-		"""Test a TimeField (read, modify, verify)."""
+		"""Test a TimeField (read, modify, verify).
+		"""
 		obj_orig = BusinessHours.objects.all()[0]
 		obj = refresh(obj_orig)
 		self.assertTrue(isinstance(obj.MondayStartTime, datetime.time))
@@ -353,7 +374,8 @@ class BasicSOQLTest(TestCase):
 			obj_orig.save()
 
 	def test_account_insert_delete(self):
-		"""Test insert and delete an account (normal or personal SF config)"""
+		"""Test insert and delete an account (normal or personal SF config)
+		"""
 		if settings.PERSON_ACCOUNT_ACTIVATED:
 			test_account = Account(FirstName='IntegrationTest',
 					LastName='Account')
@@ -367,7 +389,8 @@ class BasicSOQLTest(TestCase):
 			test_account.delete()
 
 	def test_similarity_filter_operators(self):
-		"""Test filter operators that use LIKE 'something%' and similar."""
+		"""Test filter operators that use LIKE 'something%' and similar.
+		"""
 		User.objects.get(Username__exact=current_user)
 		User.objects.get(Username__iexact=current_user.upper())
 		User.objects.get(Username__contains=current_user[1:-1])
@@ -380,7 +403,8 @@ class BasicSOQLTest(TestCase):
 
 	@skipUnless(default_is_sf, "Default database should be any Salesforce.")
 	def test_unsupported_bulk_create(self):
-		"""Unsupported bulk_create: "Errors should never pass silently." """
+		"""Unsupported bulk_create: "Errors should never pass silently."
+		"""
 		objects = [Contact(last_name='sf_test a'), Contact(last_name='sf_test b')]
 		self.assertRaises(AssertionError, Contact.objects.bulk_create, objects)
 
@@ -399,7 +423,8 @@ class BasicSOQLTest(TestCase):
 
 	@skipUnless(default_is_sf, "Default database should be any Salesforce.")
 	def test_escape_single_quote_in_raw_query(self):
-		"""Test that manual escaping within a raw query is not double escaped."""
+		"""Test that manual escaping within a raw query is not double escaped.
+		"""
 		account_name = '''Dr. Evil's Giant\\' "Laser", LLC'''
 		account = Account(Name=account_name)
 		account.save()
@@ -653,7 +678,8 @@ class BasicSOQLTest(TestCase):
 
 	@skipUnless(default_is_sf, "Default database should be any Salesforce.")
 	def test_only_fields(self):
-		"""Verify that access to "only" fields doesn't require a request, but others do."""
+		"""Verify that access to "only" fields doesn't require a request, but others do.
+		"""
 		request_count_0 = salesforce.backend.query.request_count
 		sql = User.objects.only('Username').query.get_compiler('salesforce').as_sql()[0]
 		self.assertEqual(sql, 'SELECT User.Id, User.Username FROM User')
@@ -671,7 +697,8 @@ class BasicSOQLTest(TestCase):
 
 	@skipUnless(default_is_sf, "Default database should be any Salesforce.")
 	def test_defer_fields(self):
-		"""Verify that access to a deferred field requires a new request, but others don't."""
+		"""Verify that access to a deferred field requires a new request, but others don't.
+		"""
 		request_count_0 = salesforce.backend.query.request_count
 		contact = Contact.objects.defer('email')[0]
 		self.assertEqual(salesforce.backend.query.request_count, request_count_0 + 1)
@@ -685,8 +712,9 @@ class BasicSOQLTest(TestCase):
 
 	@skipUnless(default_is_sf, "Default database should be any Salesforce.")
 	def test_filter_by_more_fk_to_the_same_model(self):
-		"""Test that aliases are correctly decoded if more relations to
-		the same model are present in the filter.
+		"""Test a filter with more relations to the same model.
+		
+		Verify that aliases are correctly decoded in the query compiler.
 		"""
 		test_lead = Lead(Company='sf_test lead', LastName='name')
 		test_lead.save()

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -377,8 +377,9 @@ class BasicSOQLRoTest(TestCase):
 	def test_raw_query_empty(self):
 		"""Test that the raw query works even for queries with empty results.
 
-		This improvement over normal Django can compensate some unimplemented
-		features of django-salesforce.
+		Raw queries with supported empty results are an improvement over normal
+		Django.	It is useful if some unimplemented features
+		of django-salesforce are solved by writing a raw query.
 		"""
 		len(list(Contact.objects.raw("SELECT Id, FirstName FROM Contact WHERE FirstName='nonsense'")))
 
@@ -684,7 +685,7 @@ class BasicSOQLRoTest(TestCase):
 	def test_subquery_condition(self):
 		"""Regression test with a filter based on subquery.
 
-		Django 1.7 had a problem while 1.6 was OK. The example is very similar to PR #103.
+		This test is very similar to the required example in PR #103.
 		"""
 		qs = OpportunityContactRole.objects.filter(role='abc',
 				opportunity__in=Opportunity.objects.filter(stage='Prospecting'))

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -759,6 +759,16 @@ class BasicSOQLTest(TestCase):
 			oc.delete()
 			oppo.delete()
 
+	def test_subquery_condition(self):
+		qs = OpportunityContactRole.objects.filter(role='abc',
+				opportunity__in=Opportunity.objects.filter(stage='Prospecting'))
+		sql, params = qs.query.get_compiler('salesforce').as_sql()
+		self.assertRegexpMatches(sql, 'SELECT .*OpportunityContactRole\.Role.* '
+					'FROM OpportunityContactRole WHERE \(OpportunityContactRole.Role = %s AND '
+						 'OpportunityContactRole.OpportunityId IN '
+					'\(SELECT Opportunity\.Id FROM Opportunity WHERE Opportunity\.StageName = %s\)\)'
+					)
+
 	def test_none_method_queryset(self):
 		"""Test that none() method in the queryset returns [], not error"""
 		request_count_0 = salesforce.backend.query.request_count

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -710,11 +710,12 @@ class BasicSOQLTest(TestCase):
 			test_lead.delete()
 
 	def test_none_method_queryset(self):
-		"""Test that none() method in the queryset return [], not error"""
+		"""Test that none() method in the queryset returns [], not error"""
 		request_count_0 = salesforce.backend.query.request_count
 		self.assertEqual(tuple(Contact.objects.none()), ())
 		self.assertEqual(tuple(Contact.objects.all().none().all()), ())
 		self.assertEqual(repr(Contact.objects.none()), '[]')
 		self.assertEqual(salesforce.backend.query.request_count, request_count_0,
 				"Do database requests should be done with .none() method")
+
 	#@skip("Waiting for bug fix")

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -709,4 +709,12 @@ class BasicSOQLTest(TestCase):
 		finally:
 			test_lead.delete()
 
+	def test_none_method_queryset(self):
+		"""Test that none() method in the queryset return [], not error"""
+		request_count_0 = salesforce.backend.query.request_count
+		self.assertEqual(tuple(Contact.objects.none()), ())
+		self.assertEqual(tuple(Contact.objects.all().none().all()), ())
+		self.assertEqual(repr(Contact.objects.none()), '[]')
+		self.assertEqual(salesforce.backend.query.request_count, request_count_0,
+				"Do database requests should be done with .none() method")
 	#@skip("Waiting for bug fix")

--- a/salesforce/tests/test_utils.py
+++ b/salesforce/tests/test_utils.py
@@ -6,6 +6,9 @@ import unittest
 from salesforce.testrunner.example.models import Account, Contact, Lead, Opportunity
 from salesforce.utils import convert_lead
 from .utils import skip, skipUnless
+
+from salesforce.backend.subselect import TestSubSelectSearch
+
 try:
     import beatbox
 except ImportError:

--- a/tests/inspectdb/slow_test.py
+++ b/tests/inspectdb/slow_test.py
@@ -78,6 +78,8 @@ def run():
 					'Folder',
 					# Records with some values of UserShare.RowCause can not be updated.
 					'UserShare',
+					# Cannot directly insert FeedItem with type TrackedChange
+					'FeedItem',
 					):
 				stdout.write('(write) ')
 				try:

--- a/tests/test_lazy_connect/tests.py
+++ b/tests/test_lazy_connect/tests.py
@@ -7,8 +7,8 @@ from requests.exceptions import ConnectionError
 class LazyTest(TestCase):
 	def test_lazy_connection(self):
 		"""
-		Verify that the plain access to SF connection object does not raises
-		exceptions vith SF_LAZY_CONNECT if SF is not accessible.
+		Verify that the plain access to SF connection object does not raise
+		exceptions with SF_LAZY_CONNECT if SF is not accessible.
 		"""
 		# verify that access to a broken connection does not raise exception
 		sf_conn = connections['salesforce']


### PR DESCRIPTION
- Implemented Many2many realtionship so that the related name .all() and the reverse related name .all() works, with Django 1.4 to 1.8

- Speed up tests. The connection to SFDC is not created until necessary, because some tests don't require the connection at all.

closes #103, #124  