### PR TITLE
Fixed query compiler

### DIFF
--- a/salesforce/backend/compiler.py
+++ b/salesforce/backend/compiler.py
@@ -310,7 +310,7 @@ class SQLCompiler(compiler.SQLCompiler):
 						join_cols = join_cols[1], join_cols[0]
 					if lhs in work_lhses:
 						assert not rhs in soql_trans
-						if rhs.endswith('__c'):
+						if join_cols[0].endswith('__c'):
 							fkey = re.sub('__c$', '__r', join_cols[0])
 						else:
 							fkey = re.sub('Id$', '', join_cols[0])

--- a/salesforce/backend/compiler.py
+++ b/salesforce/backend/compiler.py
@@ -258,7 +258,10 @@ class SQLCompiler(compiler.SQLCompiler):
 			join_map_items = [((getattr(v, 'parent_alias', None), v.table_name, getattr(v, 'join_cols', None)),
 							   (v.table_alias,)) for k, v in query.alias_map.items()]
 		elif DJANGO_17_PLUS:
-			join_map_items = list(query.join_map.items())
+			# TODO rewrite it to use also alias_map, because join_map is obsoleted, removed in Django 1.8
+			#      Django 1.7 has the same structure JoinInfo as Django 1.6
+			join_map_items = [((v.lhs_alias, v.table_name, v.join_cols), (v.rhs_alias,))
+							   for k, v in query.alias_map.items()]
 		elif DJANGO_16_PLUS:
 			join_map_items = [((v.lhs_alias, v.table_name, v.join_cols), (v.rhs_alias,))
 							   for k, v in query.alias_map.items()]

--- a/salesforce/tests/__init__.py
+++ b/salesforce/tests/__init__.py
@@ -1,5 +1,8 @@
 # These imports are necessary only with old Django 1.5.x and older.
-# Nothing common for test sub-modules can be here.
+# Nothing common useful for test sub-modules can be here, because
+# modules inside should not create a cyclic dependency, independent
+# modules shouldn't be forced to import example.models that causes
+# validation errors.
 from salesforce.tests.test_auth import *
 from salesforce.tests.test_integration import *
 from salesforce.tests.test_browser import *

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -275,16 +275,6 @@ class BasicSOQLRoTest(TestCase):
 			attachment.delete()
 			obj.delete()
 
-	def test_namespaces_auto(self):
-		"""Verify that the database column name can be correctly autodetected
-
-		from model Meta for managed packages with a namespace prefix.
-		(The package need not be installed for this unit test.)
-		"""
-		tested_field = ChargentOrder._meta.get_field('Balance_Due')
-		self.assertEqual(tested_field.sf_custom, True)
-		self.assertEqual(tested_field.column, 'ChargentOrders__Balance_Due__c')
-
 	def test_datetime_miliseconds(self):
 		"""Verify that a field with milisecond resolution is readable.
 		"""
@@ -682,30 +672,6 @@ class BasicSOQLRoTest(TestCase):
 		qs = Attachment.objects.filter(parent__in=Test.objects.filter(contact__last_name='Johnson'))
 		list(qs)
 
-	def test_subquery_condition(self):
-		"""Regression test with a filter based on subquery.
-
-		This test is very similar to the required example in PR #103.
-		"""
-		qs = OpportunityContactRole.objects.filter(role='abc',
-				opportunity__in=Opportunity.objects.filter(stage='Prospecting'))
-		sql, params = qs.query.get_compiler('salesforce').as_sql()
-		self.assertRegexpMatches(sql, "WHERE Opportunity.StageName =",
-					"Probably because aliases are invalid for SFDC, e.g. 'U0.StageName'")
-		self.assertRegexpMatches(sql, 'SELECT .*OpportunityContactRole\.Role.* '
-										'FROM OpportunityContactRole WHERE \(.* AND .*\)')
-		self.assertRegexpMatches(sql, 'OpportunityContactRole.OpportunityId IN '
-					'\(SELECT Opportunity\.Id FROM Opportunity WHERE Opportunity\.StageName = %s ?\)')
-		self.assertRegexpMatches(sql, 'OpportunityContactRole.Role = %s')
-
-	def test_none_method_queryset(self):
-		"""Test that none() method in the queryset returns [], not error"""
-		request_count_0 = salesforce.backend.query.request_count
-		self.assertEqual(tuple(Contact.objects.none()), ())
-		self.assertEqual(tuple(Contact.objects.all().none().all()), ())
-		self.assertEqual(repr(Contact.objects.none()), '[]')
-		self.assertEqual(salesforce.backend.query.request_count, request_count_0,
-				"Do database requests should be done with .none() method")
 
 # ============= Tests that need setUp Lead ==================
 

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -770,7 +770,8 @@ class BasicLeadSOQLTest(TestCase):
 		"""
 		self.test_lead.delete()
 		# TODO optimize counting because this can load thousands of records
-		count_deleted = Lead.objects.db_manager(sf_alias).query_all().filter(IsDeleted=True, LastName="Unittest General").count()
+		count_deleted = Lead.objects.db_manager(sf_alias).query_all(
+				).filter(IsDeleted=True, LastName="Unittest General").count()
 		if not default_is_sf:
 			self.skipTest("Default database should be any Salesforce.")
 		self.assertGreaterEqual(count_deleted, 1)

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -24,7 +24,7 @@ from salesforce.testrunner.example.models import Test as TestCustomExample
 from salesforce import router, DJANGO_15_PLUS
 from salesforce.backend import sf_alias
 import salesforce
-from .utils import skip, skipUnless
+from .utils import skip, skipUnless, expectedFailure
 
 import logging
 log = logging.getLogger(__name__)
@@ -657,7 +657,7 @@ class BasicSOQLRoTest(TestCase):
 			oc.delete()
 			oppo.delete()
 
-	@skip("Waiting for bug fix")
+	@expectedFailure
 	def test_filter_custom(self):
 		"""Verify that relations between custom and builtin objects
 		
@@ -798,5 +798,3 @@ class BasicLeadSOQLTest(TestCase):
 			note_1.delete()
 			note_2.delete()
 			test_contact.delete()
-
-	#@skip("Waiting for bug fix")

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -658,7 +658,6 @@ class BasicSOQLRoTest(TestCase):
 			oc.delete()
 			oppo.delete()
 
-	@expectedFailure
 	def test_filter_custom(self):
 		"""Verify that relations between custom and builtin objects
 		

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -262,7 +262,7 @@ class BasicSOQLRoTest(TestCase):
 		"""Create, read and delete a simple custom object `django_Test__c`.
 		"""
 		if not 'django_Test__c' in sf_tables():
-			skip("Not found custom object 'django_Test__c'")
+			self.skipTest("Not found custom object 'django_Test__c'")
 		results = TestCustomExample.objects.all()[0:1]
 		obj = TestCustomExample(test_text='sf_test')
 		obj.save()

--- a/salesforce/tests/test_utils.py
+++ b/salesforce/tests/test_utils.py
@@ -7,8 +7,6 @@ from salesforce.testrunner.example.models import Account, Contact, Lead, Opportu
 from salesforce.utils import convert_lead
 from .utils import skip, skipUnless
 
-from salesforce.backend.subselect import TestSubSelectSearch
-
 try:
     import beatbox
 except ImportError:

--- a/salesforce/tests/utils.py
+++ b/salesforce/tests/utils.py
@@ -4,3 +4,7 @@ try:
 except ImportError:
 	# old Python 2.6 (Django 1.4 - 1.6 simulated unittest2)
 	from django.utils.unittest import skip, skipUnless, expectedFailure
+
+import uuid
+# random string for test that accidentally run concurrent
+uid = '-' + str(uuid.uuid4())[:7]

--- a/salesforce/tests/utils.py
+++ b/salesforce/tests/utils.py
@@ -1,6 +1,6 @@
 "Utilities useful for tests"
 try:
-	from unittest import skip, skipUnless
+	from unittest import skip, skipUnless, expectedFailure
 except ImportError:
 	# old Python 2.6 (Django 1.4 - 1.6 simulated unittest2)
-	from django.utils.unittest import skip, skipUnless
+	from django.utils.unittest import skip, skipUnless, expectedFailure

--- a/tests/test_compatibility/tests.py
+++ b/tests/test_compatibility/tests.py
@@ -4,20 +4,22 @@ from django.conf import settings
 from django.test import TestCase
 from salesforce.backend import sf_alias
 from tests.test_compatibility.models import Lead, User
+import uuid
+uid = '-' + str(uuid.uuid4())[:7]
 
 current_user = settings.DATABASES[sf_alias]['USER']
 
 
 class CompatibilityTest(TestCase):
 	def test_capitalized_id(self):
-		test_lead = Lead(Company='sf_test lead', LastName='name')
+		test_lead = Lead(Company='sf_test lead' + uid, LastName='name')
 		test_lead.save()
 		try:
 			refreshed_lead = Lead.objects.get(Id=test_lead.Id)
 			self.assertEqual(refreshed_lead.Id, test_lead.Id)
 			self.assertEqual(refreshed_lead.Owner.Username, current_user)
-			leads = Lead.objects.filter(Company='sf_test lead', LastName='name')
-			self.assertEqual(len(leads), 1)
+			leads = Lead.objects.filter(Company='sf_test lead' + uid, LastName='name')
+			self.assertGreaterEqual(len(leads), 1)
 			repr(test_lead.__dict__)
 		finally:
 			test_lead.delete()

--- a/tests/test_mixin/tests.py
+++ b/tests/test_mixin/tests.py
@@ -3,6 +3,8 @@ from django.conf import settings
 from django.test import TestCase
 from salesforce.backend import sf_alias
 from tests.test_mixin.models import Account, Contact, User, ProxyContact, Proxy2Contact
+import uuid
+uid = '-' + str(uuid.uuid4())[:7]
 
 current_user = settings.DATABASES[sf_alias]['USER']
 
@@ -19,7 +21,7 @@ class MixinTest(TestCase):
 	def test_mixin(self):
 		"""Test that mixins from abstract classes work and also proxy models."""
 		# create the object with one field from the second ancestor and one from the first
-		test_account = Account(name='sf_test account', description='experimental')
+		test_account = Account(name='sf_test account' + uid, description='experimental')
 		test_account.save()
 		test_account = refresh(test_account)
 		test_contact = Contact(first_name='sf_test', last_name='my', account=test_account)
@@ -28,8 +30,8 @@ class MixinTest(TestCase):
 			test_contact = refresh(test_contact)
 			# verify foreign keys to and from the complicated model
 			self.assertEqual(test_contact.account.owner.username, current_user)
-			contacts = Contact.objects.filter(account__name='sf_test account')  # description='experimental')
-			self.assertEqual(len(contacts), 1)
+			contacts = Contact.objects.filter(account__name='sf_test account' + uid)  # description='experimental')
+			self.assertGreaterEqual(len(contacts), 1)
 			repr(test_contact.__dict__)
 			repr(test_account.__dict__)
 			# Verify that a proxy model correctly recognizes the db_table from


### PR DESCRIPTION
I think it is an important fix and a big part of issues is now ready. The standard result is currently 5 skipped tests for SSL.

I also have sometimes the problem that while long queue of tests is running I need to try one short test. I improved it again.

Other important fix will be query_results method of query. I can continue in September.