### PR TITLE
add range lookup functionality

### DIFF
--- a/salesforce/backend/compiler.py
+++ b/salesforce/backend/compiler.py
@@ -601,8 +601,8 @@ if DJANGO_17_PLUS:
 
 	models.Field.register_lookup(IsNull)
 
-
-	class Range(models.Field.get_lookup(models.Field(), 'range')):
+        BaseRange = models.Field.get_lookup(models.Field(), 'range')
+	class Range(BaseRange):
 		# The expected result base class above is `models.lookups.Range`.
 		lookup_name = 'range'
 

--- a/salesforce/backend/compiler.py
+++ b/salesforce/backend/compiler.py
@@ -381,10 +381,6 @@ class SalesforceWhereNode(where.WhereNode):
 				return ('%s %snull' % (field_sql,
 					(not value_annot and '!= ' or '= ')), ())
 
-			if lookup_type == 'range':
-				return ('%s >= %s AND %s <= %s' % (field_sql,
-												   value_annot[0], field_sql,
-												   value_annot[1]), ())
 		else:
 			return result
 

--- a/salesforce/backend/compiler.py
+++ b/salesforce/backend/compiler.py
@@ -345,7 +345,7 @@ class SQLCompiler(compiler.SQLCompiler):
 
 
 class SalesforceWhereNode(where.WhereNode):
-	overridden_types = ['isnull', 'range']
+	overridden_types = ['isnull']
 
 	# Simple related fields work only without this, but for more complicated
 	# cases this must be fixed and re-enabled.
@@ -601,8 +601,8 @@ if DJANGO_17_PLUS:
 
 	models.Field.register_lookup(IsNull)
 
-        BaseRange = models.Field.get_lookup(models.Field(), 'range')
-	class Range(BaseRange):
+
+	class Range(models.lookups.Range):
 		# The expected result base class above is `models.lookups.Range`.
 		lookup_name = 'range'
 

--- a/salesforce/testrunner/example/models.py
+++ b/salesforce/testrunner/example/models.py
@@ -295,6 +295,9 @@ class Opportunity(SalesforceModel):
 	contacts = django.db.models.ManyToManyField(Contact, through='example.OpportunityContactRole', related_name='opportunities')
 	close_date = models.DateField()
 	stage = models.CharField(max_length=255, db_column='StageName') # e.g. "Prospecting"
+	created_date = models.DateTimeField(sf_read_only=models.READ_ONLY)
+	amount = models.DecimalField(max_digits=18, decimal_places=2, blank=True, null=True)
+	next_step = models.CharField(max_length=255, blank=True)
 
 
 class OpportunityContactRole(SalesforceModel):

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -704,10 +704,18 @@ class BasicLeadSOQLTest(TestCase):
 		)
 		self.objs = []
 		self.test_lead.save()
+		self.test_opportunity = Opportunity(
+			name	= "Example Opportunity",
+			close_date	= datetime.date(year=2015, month=7, day=30),
+			stage	= "Prospecting"
+		)
+		self.test_opportunity.save()
 		if not default_is_sf:
 			add_obj(Contact(last_name='Test contact 1'))
 			add_obj(Contact(last_name='Test contact 2'))
 			add_obj(User(Username=current_user))
+			add_obj(Opportunity(Name='Example Opportunity',
+								close_date=datetime.date(year=2015, month=7, day=30, stage="Prospecting")))
 	
 	def tearDown(self):
 		"""Clean up our test records.
@@ -749,6 +757,15 @@ class BasicLeadSOQLTest(TestCase):
 		lead = Lead.objects.get(Email__isnull=False, FirstName='User' + uid)
 		self.assertEqual(lead.FirstName, 'User' + uid)
 		self.assertEqual(lead.LastName, 'Unittest General')
+
+	def test_range_lookup(self):
+		"""Get the test opportunity record by range condition.
+		"""
+		start_date = datetime.date(year=2015, month=7, day=29)
+		end_date = datetime.date(year=2015, month=8, day=01)
+		oppy = Opportunity.objects.filter(close_date__range=(start_date, end_date))[0]
+		self.assertEqual(oppy.name, 'Example Opportunity')
+		self.assertEqual(oppy.stage, 'Prospecting')
 	
 	def test_update(self):
 		"""Update the test lead record.

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -767,7 +767,7 @@ class BasicLeadSOQLTest(TestCase):
 
 		# Test date objects
 		start_date = datetime.date(year=2015, month=7, day=29)
-		end_date = datetime.date(year=2015, month=8, day=01)
+		end_date = datetime.date(year=2015, month=8, day=1)
 		oppy = Opportunity.objects.filter(close_date__range=(start_date, end_date))[0]
 		self.assertEqual(oppy.name, 'Example Opportunity')
 		self.assertEqual(oppy.stage, 'Prospecting')

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -707,7 +707,9 @@ class BasicLeadSOQLTest(TestCase):
 		self.test_opportunity = Opportunity(
 			name	= "Example Opportunity",
 			close_date	= datetime.date(year=2015, month=7, day=30),
-			stage	= "Prospecting"
+			stage	= "Prospecting",
+			amount 	= 130000.00,
+			next_step	= "g"
 		)
 		self.test_opportunity.save()
 		if not default_is_sf:
@@ -715,7 +717,8 @@ class BasicLeadSOQLTest(TestCase):
 			add_obj(Contact(last_name='Test contact 2'))
 			add_obj(User(Username=current_user))
 			add_obj(Opportunity(Name='Example Opportunity',
-								close_date=datetime.date(year=2015, month=7, day=30, stage="Prospecting")))
+								close_date=datetime.date(year=2015, month=7, day=30, stage="Prospecting"),
+								amount=130000.00, next_step='g'))
 	
 	def tearDown(self):
 		"""Clean up our test records.
@@ -761,11 +764,38 @@ class BasicLeadSOQLTest(TestCase):
 	def test_range_lookup(self):
 		"""Get the test opportunity record by range condition.
 		"""
+
+		# Test date objects
 		start_date = datetime.date(year=2015, month=7, day=29)
 		end_date = datetime.date(year=2015, month=8, day=01)
 		oppy = Opportunity.objects.filter(close_date__range=(start_date, end_date))[0]
 		self.assertEqual(oppy.name, 'Example Opportunity')
 		self.assertEqual(oppy.stage, 'Prospecting')
+
+		# Test datetime objects
+		start_time = datetime.datetime.now() - datetime.timedelta(hours=23)
+		end_time = datetime.datetime.now()
+		oppy = Opportunity.objects.filter(created_date__range=(start_time, end_time))[0]
+		self.assertEqual(oppy.name, 'Example Opportunity')
+		self.assertEqual(oppy.stage, 'Prospecting')
+
+		# Test DecimalField
+		low_amount = 100000.00
+		high_amount = 140000.00
+		oppy = Opportunity.objects.filter(amount__range=(low_amount, high_amount))[0]
+
+		self.assertEqual(oppy.name, 'Example Opportunity')
+		self.assertEqual(oppy.stage, 'Prospecting')
+		self.assertEqual(oppy.amount, 130000.00)
+
+		# Test CharField
+		low_letter = 'b'
+		high_letter = 'h'
+		oppy = Opportunity.objects.filter(next_step__range=(low_letter, high_letter))[0]
+
+		self.assertEqual(oppy.name, 'Example Opportunity')
+		self.assertEqual(oppy.stage, 'Prospecting')
+		self.assertEqual(oppy.amount, 130000.00)
 	
 	def test_update(self):
 		"""Update the test lead record.


### PR DESCRIPTION
This pull request modifies the range lookup provided by Django to render the correct SOQL code for the Salesforce API.  The reason this is needed is that Salesforce does not recognize the BETWEEN clause in SOQL.

Prior to this pull request:
```
today = datetime.date.today()
yesterday = today - datetime.timedelta(days=1)
opportunities = Opportunity.objects.filter(close_date__range(yesterday, today))
```
generated this SQL:
```
'SELECT <<my_opportunity_fields>> FROM Opportunity WHERE Opportunity.close_date BETWEEN %s AND %s', (datetime.date(2015, 9, 1), datetime.date(2015, 9, 2))
```
This pull request now renders this SOQL:
```
'SELECT <<my_opportunity_fields>> FROM Opportunity WHERE Opportunity.close_date >= %s AND Opportunity.close_date <= %s', (datetime.date(2015, 9, 1), datetime.date(2015, 9, 2))
```
I used the work done on the isnull lookup and this link as references.  

https://docs.djangoproject.com/en/1.8/howto/custom-lookups/#writing-alternative-implementations-for-existing-lookups

I wrote a test for it as well.  Let me know what you think.  Thanks!

