### PR TITLE
Fixed test to work with both possible SF_PK id/Id.

### DIFF
--- a/salesforce/tests/test_utils.py
+++ b/salesforce/tests/test_utils.py
@@ -43,7 +43,7 @@ class UtilitiesTest(TestCase):
             ret2 = convert_lead(lead2, doNotCreateOpportunity=True, accountId=ret['accountId'])
             account = Account.objects.get(pk=ret['accountId'])
             # verify that account is merged
-            self.assertEqual(ret2['accountId'], account.Id)
+            self.assertEqual(ret2['accountId'], account.pk)
             self.assertEqual(account.BillingStreet, 'Test Avenue 45')
             self.assertEqual(account.Phone, '123456789')
         finally:


### PR DESCRIPTION
The older setting `SF_PK='Id'` is probably still easier for people who use also other developer tools and other API or a raw SOQL for work with Salesforce. This convention is not The default `SF_PK='id'` is preferable for people who mostly use only Django-salesforce. I also try both if I am developing something in the compiler because I believe that it helps to find subtle bugs and misconception before committing. Sometimes it saves a development on new idea that initially works only with one of these settings.