### PR TITLE
Automatic admin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,30 +72,40 @@ Quick Start
    tests for django_salesforce requires many permissions or Administrator
    account for sandbox.
 
-4. **(optional)** To override the default timeout of 15 seconds,
-   define ``SALESFORCE_QUERY_TIMEOUT`` in your settings file::
-
-    SALESFORCE_QUERY_TIMEOUT = 15
-
-5. **(optional)** If you want to use another name for your Salesforce DB
-   connection, define ``SALESFORCE_DB_ALIAS`` in your settings file::
-
-    SALESFORCE_DB_ALIAS = 'salesforce'
-
-6. Add ``salesforce.router.ModelRouter`` to your ``DATABASE_ROUTERS``
+4. Add ``salesforce.router.ModelRouter`` to your ``DATABASE_ROUTERS``
    setting::
 
     DATABASE_ROUTERS = [
         "salesforce.router.ModelRouter"
     ]
 
-7. Define a model that extends ``salesforce.models.Model`` or export the
+5. Define a model that extends ``salesforce.models.Model`` or export the
    complete SF schema by ``python manage.py inspectdb --database=salesforce``
    and simplify it to what you need.
 
+6. **(optional)** To override the default timeout of 15 seconds,
+   define ``SALESFORCE_QUERY_TIMEOUT`` in your settings file::
+
+    SALESFORCE_QUERY_TIMEOUT = 15  # default
+
+7. **(optional)** If you want to use another name for your Salesforce DB
+   connection, define ``SALESFORCE_DB_ALIAS`` in your settings file::
+
+    SALESFORCE_DB_ALIAS = 'salesforce'  # default
+
 8. You're all done! Just use your model like a normal Django model.
 
-9. (Optional) Create a normal Django admin.py module for your Salesforce model.
+9. (Optional) Create a normal Django ``admin.py`` module for your Salesforce model::
+
+    from salesforce.testrunner.example.universal_admin import register_omitted_classes
+    # some admin classes that you wrote manually yet
+    # ...
+    # end of file
+    register_omitted_classes(your_application.models)
+
+This is a rudimentary way to verify that every model works in sandbox, before
+handwritting all admin classes. (Foreign keys to huge tables in the production
+require customized admins e.g. with search widgets.)
 
 Primary Key
 -----------

--- a/salesforce/backend/compiler.py
+++ b/salesforce/backend/compiler.py
@@ -285,7 +285,10 @@ class SQLCompiler(compiler.SQLCompiler):
 		assert len(alias2table) == len(alias_map_items)
 		# Recognize the top table
 		assert len(side_l.union(side_r)) == len(alias_map_items)
-		(top_lhs,) = set(side_l).difference(side_r)
+		top_lhs_set = set(side_l).difference(side_r)
+		assert len(top_lhs_set) == 1, ("Only queries with one top child model are "
+									   "supported by Salesforce. Use a subquery.")
+		(top_lhs,) = top_lhs_set
 		self.root_alias = top_lhs
 		# translation rules into SOQL
 		soql_trans = {top_lhs: alias2table[top_lhs]}

--- a/salesforce/testrunner/example/universal_admin.py
+++ b/salesforce/testrunner/example/universal_admin.py
@@ -14,14 +14,18 @@ def register_omitted_classes(models):
 	# This can be improved for fields that are only not creatable but are updateable or viceversa.
 	for mdl in models.__dict__.values():
 		if hasattr(mdl, '_salesforce_object') and not mdl._meta.abstract:
+			attributes = {
+				'readonly_fields':
+					[fld.name for fld in mdl._meta.fields if getattr(fld, 'sf_read_only', 0)]
+			}
+			list_display = [fld.name for fld in mdl._meta.fields if fld.column.lower() == 'name']
+			if list_display:
+				attributes['list_display'] = list_display
 			try:
-				admin.site.register(
-					mdl,
-					type(
-						type(mdl).__name__ + 'Admin',
-						(admin.ModelAdmin,),
-						{'readonly_fields': [mdl.name for mdl in mdl._meta.fields if getattr(mdl, 'sf_read_only', 0)]}
-					)
+				admin.site.register(mdl,
+									type(type(mdl).__name__ + 'Admin',
+										 (admin.ModelAdmin,),
+										 attributes)
 				)
 			except admin.sites.AlreadyRegistered:
 				pass

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -715,9 +715,9 @@ class BasicSOQLRoTest(TestCase):
 		contact = Contact.objects.all()[0]
 		oppo = Opportunity(name='test op', stage='Prospecting', close_date=datetime.date.today())
 		oppo.save()
-		oc = OpportunityContactRole(opportunity=oppo, contact=contact, role='rolicka')
+		oc = OpportunityContactRole(opportunity=oppo, contact=contact, role='sponsor')
 		oc.save()
-		oc2 = OpportunityContactRole(opportunity=oppo, contact=contact, role='rolicka')
+		oc2 = OpportunityContactRole(opportunity=oppo, contact=contact, role='evaluator')
 		oc2.save()
 		try:
 			qs = contact.opportunities.all()

--- a/wiki/Error-messages.md
+++ b/wiki/Error-messages.md
@@ -1,0 +1,14 @@
+Help for some Error Messages
+----------------------------
+
+**Q:** `"...Error: Table 'my_sfdc_application.SomeTable' doesn't exist"` is reported on a line in program file like "...sqlite...", "...postgres..." or "...mysql...".
+
+* Missed to set `DATABASE_ROUTERS = ["salesforce.router.ModelRouter"]` in your `settings.py` and therefore the "default" database is used instead of "salesforce"
+* Missed to use the base class `salesforce.models.Model` instead of `django.db.models.Model` in that your model class.  
+  
+  
+**Q:** `SalesforceError: {'errorCode': 'INVALID_TYPE', 'message': "... FROM SomeSObject ...`  
+  `sObject type 'SomeSObject' is not supported. ..."`
+
+* Typo in the `db_table` name that doesn't equal to object's `API Name` in Salesforce (e.g. missing "__c").  
+* The current user's permissions are insufficient for this sObject type. Some fields created by installed packages or by API calls can be set without permissions even for the System Administrator profile if he doesn't add permission himself.

--- a/wiki/Experimental-Features.rest
+++ b/wiki/Experimental-Features.rest
@@ -1,4 +1,5 @@
-**Django-Admin Support** - If you use multiple Salesforce databases or multiple instances of AdminSite, you'll probably want to extend ``salesforce.admin.RoutedModelAdmin``" in your admin.py
+**Django-Admin Support** - If you use multiple Salesforce databases or multiple instances of AdminSite, you'll
+probably want to extend ``salesforce.admin.RoutedModelAdmin``" in your admin.py
 
 **Dynamic authorization** - The original use-case for django-salesforce assumed
 use of a single set of credentials with read-write access to all necessary objects.

--- a/wiki/Foreign-Key-Support.rest
+++ b/wiki/Foreign-Key-Support.rest
@@ -28,7 +28,7 @@ You can compare the the query compiled to SOQL and to SQL::
     print(my_qs.query.get_compiler('salesforce').as_sql())   # SOQL
     print(my_qs.query.get_compiler('default').as_sql())      # SQL
 
-::  comment until the end of identation
+..  comment until the end of identation
     Related objects (Lookup field or Master-Detail Relationship) use two different names in
     `SOQL <http://www.salesforce.com/us/developer/docs/soql_sosl/>`__. If the
     relation is by ID the columns are named ``FieldName__c``, whereas if the relation

--- a/wiki/Introspection-and-Special-Attributes-of-Fields.rest
+++ b/wiki/Introspection-and-Special-Attributes-of-Fields.rest
@@ -57,7 +57,16 @@ can see the most complete form in the output of ``inspectdb``.
    is also expected and migrations of any SalesforceModel will be created then
    explicit names in the code are better: ``--verbosity=2``.
 
----
+
+-  **ForeignKey(unique=True)** SFDC doesn't allow to create a custom one-to-one
+   relationship field. SFDC uses it currently only in three internal objects whose structure
+   is not accessible through the SF user interface. A warning that OneToOneField
+   would be better for such fields is reported by Django 1.9 if
+   a ForeignKey(... unique=True) field is in a model. It is expected that
+   most of developers don't need these models or can use a ForeignKey and ignore the warning.
+   The OneToOneField will be not not implemented until Salesforce allows to create
+   such custom fields.
+
 
 SOAP API
 --------


### PR DESCRIPTION
small updates
- improved the automatic admin so that it can be used for the first experiments in quick start readme.
- clear error message for one-to-one field that it is unsupported by Django
- fixed some text
- synchronized "wiki" subdirectory with the manually edited online Wiki
