### PR TITLE
Data migrations broken since 0.6.2

### DIFF
--- a/salesforce/router.py
+++ b/salesforce/router.py
@@ -71,6 +71,11 @@ class ModelRouter(object):
         """
         Don't attempt to sync SF models to non SF databases and vice versa.
         """
+
+        # data migrations can be skipped
+        if 'model' not in hints and not model_name:
+            return
+
         model = hints['model'] if 'model' in hints else apps.get_model(app_label, model_name)
         if hasattr(model, '_salesforce_object'):
             # If SALESFORCE_DB_ALIAS is e.g. a sqlite3 database, than it can migrate SF models


### PR DESCRIPTION
Data migrations don't work on a model base but the salesforce router always checks for model attributes.
Therefore RunSQL and RunPython are broken when using the salesforce router.

> Running migrations:
>   Rendering model states... DONE
>   Unapplying actionstream.0005_product_created...Traceback (most recent call last):
>   File "./manage.py", line 11, in <module>
>     execute_from_command_line(sys.argv)
>   File "/usr/local/lib/python2.7/dist-packages/django/core/management/__init__.py", line 354, in execute_from_command_line
>     utility.execute()
>   File "/usr/local/lib/python2.7/dist-packages/django/core/management/__init__.py", line 346, in execute
>     self.fetch_command(subcommand).run_from_argv(self.argv)
>   File "/usr/local/lib/python2.7/dist-packages/django/core/management/base.py", line 394, in run_from_argv
>     self.execute(*args, **cmd_options)
>   File "/usr/local/lib/python2.7/dist-packages/django/core/management/base.py", line 445, in execute
>     output = self.handle(*args, **options)
>   File "/usr/local/lib/python2.7/dist-packages/django/core/management/commands/migrate.py", line 222, in handle
>     executor.migrate(targets, plan, fake=fake, fake_initial=fake_initial)
>   File "/usr/local/lib/python2.7/dist-packages/django/db/migrations/executor.py", line 112, in migrate
>     self.unapply_migration(states[migration], migration, fake=fake)
>   File "/usr/local/lib/python2.7/dist-packages/django/db/migrations/executor.py", line 168, in unapply_migration
>     state = migration.unapply(state, schema_editor)
>   File "/usr/local/lib/python2.7/dist-packages/django/db/migrations/migration.py", line 162, in unapply
>     operation.database_backwards(self.app_label, schema_editor, from_state, to_state)
>   File "/usr/local/lib/python2.7/dist-packages/django/db/migrations/operations/special.py", line 188, in database_backwards
>     if router.allow_migrate(schema_editor.connection.alias, app_label, **self.hints):
>   File "/usr/local/lib/python2.7/dist-packages/django/db/utils.py", line 361, in allow_migrate
>     allow = method(db, app_label, **hints)
>   File "/usr/local/lib/python2.7/dist-packages/salesforce/router.py", line 74, in allow_migrate
>     model = hints['model'] if 'model' in hints else apps.get_model(app_label, model_name)
>   File "/usr/local/lib/python2.7/dist-packages/django/apps/registry.py", line 201, in get_model
>     app_label, model_name = app_label.split('.')
> ValueError: need more than 1 value to unpack
> 

Please make a new release as soon as possible. Current one is broken and prevents users from working with data migrations.