### PR TITLE
Update for the critical update Salesforce required TLSv1.1+

### DIFF
--- a/salesforce/backend/adapter.py
+++ b/salesforce/backend/adapter.py
@@ -18,10 +18,8 @@ class SslHttpAdapter(HTTPAdapter):
             Expected values are `ssl.PROTOCOL_TLSv1` or `ssl.PROTOCOL_SSLv23`.
     """
     def __init__(self, *args, **kwargs):
-        # TODO Change the default SSL version to ssl.PROTOCOL_SSLv23 in the
-        #      autumn release v0.7.
         default_ssl_version = getattr(settings, 'SF_SSL', {}).get('ssl_version',
-                ssl.PROTOCOL_TLSv1)
+                ssl.PROTOCOL_SSLv23)
         self.sf_ssl_version = kwargs.pop('ssl_version', default_ssl_version)
         super(SslHttpAdapter, self).__init__(*args, **kwargs)
 

--- a/salesforce/testrunner/settings.py
+++ b/salesforce/testrunner/settings.py
@@ -187,19 +187,6 @@ IPV4_ONLY = True
 # version "django-salesforce < 0.5".
 #SF_PK = 'Id'
 
-# This is a conditional temporary setting for tests, while Python older
-# than 2.7.9 should work but upgrade is strongly recommended.
-# The protocol TLS 1.1 or 1.2 will be indispensably in 2016.
-import ssl
-import sys
-import datetime
-if sys.version_info >= (2, 7, 9) or datetime.date.today().year >= 2016:
-    # use the best possible TLS or SSL
-    SF_SSL = {'ssl_version': ssl.PROTOCOL_SSLv23, 'skiptest_tls_11': False}
-else:
-    # use exactly TLS 1.0 on old systems
-    SF_SSL = {'ssl_version': ssl.PROTOCOL_TLSv1, 'skiptest_tls_11': True}
-
 try:
     from salesforce.testrunner.local_settings import *
 except ImportError:

--- a/salesforce/tests/test_ssl.py
+++ b/salesforce/tests/test_ssl.py
@@ -1,7 +1,8 @@
-"""no hacks -> we can import immediately
+"""SSL Tests - compatibility and some security features
 
-I expect that more services wil disable TLS 1.0 before SFDC and the maintainers of `requests` will fix the issue
-without need to monkey patch long parts of requests code or to repeat hacks like the one criticised in .... issue.
+This module will be completely obsoleted on March 4th 2017 when all sites
+enable the critical update "Require TLS 1.1 or higher for HTTPS connections"
+for all organizations uncoditionally.
 """
 from django.conf import settings
 from django.test import TestCase


### PR DESCRIPTION
This fix is important if the critical update "Require TLS 1.1 or higher for HTTPS connections" is activated in your organization SFDC Setup. (recommended)

Other possible solution is to only add a setting `SF_SSL` to project settings. [see our wiki amout SSL](https://github.com/django-salesforce/django-salesforce/wiki/SSL-TLS-settings-and-Salesforce.com)

I recommend version 0.6.2.5, because this could be blocking for organizations now.