### PR TITLE
Added __version__ string #153

### DIFF
--- a/salesforce/__init__.py
+++ b/salesforce/__init__.py
@@ -10,10 +10,13 @@ A database backend for the Django ORM.
 
 Allows access to all Salesforce objects accessible via the SOQL API.
 """
+from pkg_resources import get_distribution
 import logging
 import warnings
 
 import django
+
+__version__ = get_distribution('django-salesforce').version
 DJANGO_18_PLUS = django.VERSION[:2] >= (1, 8)
 DJANGO_184_PLUS = django.VERSION[:3] >= (1, 8, 4)
 DJANGO_19_PLUS = django.VERSION[:3] >= (1, 9)


### PR DESCRIPTION
Django has implemented `__version__` string in 1.8 release, due to [PEP 396](https://www.python.org/dev/peps/pep-0396/) (deferred) - their issue 23442. It is not too late.

This is a simple solution. Maybe I summarize a new issue related to setup.py and write a new PR.