### PR TITLE
Fix for #202, broken Python 3.5 support on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ cache:
   directories:
     - $HOME/.pip-cache/
 before_install:
+ - pyenv global system 3.5
  - if [[ $TOXENV = py35 && -f ~/virtualenv/python3.5/bin/activate ]]; then source ~/virtualenv/python3.5/bin/activate; fi
  - "pip install setuptools_git"
  - "pip install rstcheck"


### PR DESCRIPTION
As described in travis-ci/travis-ci#8363 there are some pyenv misconfigurations that were causing problems with our test run. This seems to be fixed with this branch.