### PR TITLE
Fixes to overall Python architecture for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,11 @@ cache:
     - $HOME/.pip-cache/
     - $HOME/.pyenv/
 before_install:
- - pyenv install --skip-existing 2.7.15 3.4.9 3.5.5 3.6.7 3.7.1
+ - pyenv install --skip-existing 2.7.15
+ - pyenv install --skip-existing 3.4.9
+ - pyenv install --skip-existing 3.5.5
+ - pyenv install --skip-existing 3.6.7
+ - pyenv install --skip-existing 3.7.1
 install:
   - pip install rstcheck setuptools_git tox tox-pyenv
   - pyenv root

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ install:
 script:
   - rstcheck README.rst
   - echo -e "SF_PK = 'Id'" > salesforce/testrunner/local_settings.py
-  - tox -r py27-dj111,py36-dj20,py36-dj21,py35-dj110
+  - tox -r -e py27-dj111,py36-dj20,py36-dj21,py35-dj110

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,19 @@ cache:
     - $HOME/.pip-cache/
     - $HOME/.pyenv/
 before_install:
+ - git clone git://github.com/pyenv/pyenv-update.git $(pyenv root)/plugins/pyenv-update
+ - pyenv update
  - pyenv install --list
  - pyenv install --skip-existing 2.7.15
  - pyenv install --skip-existing 3.4.7
  - pyenv install --skip-existing 3.5.4
  - pyenv install --skip-existing 3.6.3
- - pyenv install --skip-existing 3.7-dev
+ #- pyenv install --skip-existing 3.7-dev
 install:
   - pip install rstcheck setuptools_git tox tox-pyenv
   - pyenv root
-  - pyenv local 2.7.15 3.4.7 3.5.4 3.6.3 3.7-dev
+  - pyenv local 2.7.15 3.4.7 3.5.4 3.6.3
+  # 3.7-dev
 script:
   - rstcheck README.rst
   - echo -e "SF_PK = 'Id'" > salesforce/testrunner/local_settings.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,19 +14,14 @@ cache:
     - $HOME/.pyenv/
 before_install:
  - git clone git://github.com/pyenv/pyenv-update.git $(pyenv root)/plugins/pyenv-update
- - pyenv update
  - pyenv install --list
  - pyenv install --skip-existing 2.7.15
- - pyenv install --skip-existing 3.4.7
  - pyenv install --skip-existing 3.5.4
  - pyenv install --skip-existing 3.6.3
- #- pyenv install --skip-existing 3.7-dev
 install:
   - pip install rstcheck setuptools_git tox tox-pyenv
-  - pyenv root
-  - pyenv local 2.7.15 3.4.7 3.5.4 3.6.3
-  # 3.7-dev
+  - pyenv local 2.7.15 3.5.4 3.6.3
 script:
   - rstcheck README.rst
   - echo -e "SF_PK = 'Id'" > salesforce/testrunner/local_settings.py
-  - tox -r 
+  - tox -r py27-dj111,py36-dj20,py36-dj21,py35-dj110

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: python
-python: "3.6"
-dist: trusty
+dist: xenial
 env:
   global:
     - secure: "Z6wS6a/YcyT8w5l+2HfMItbn2mbv+f1W43WixoqB4QkgiocjBWvmAQD6PN1sEgWVmZlRvWCABK8FcGG+Y6RPFeNdCE0U1h9hEgOiAnhUpWWH/AhOYDZ0PnFwA3/iRrHS2VFPmhdkjw1BUEfqXaJfDYtlZLgpMMfRvEjIJ8Uqq6M="
@@ -12,14 +11,14 @@ env:
 cache:
   directories:
     - $HOME/.pip-cache/
+    - $HOME/.pyenv/
 before_install:
- # - pyenv global system 3.5
- # - if [[ $TOXENV = py35 && -f ~/virtualenv/python3.5/bin/activate ]]; then source ~/virtualenv/python3.5/bin/activate; fi
- - "pip install setuptools_git"
- - "pip install rstcheck"
+ - pyenv install --skip-existing 2.7.15 3.4.9 3.5.5 3.6.7 3.7.1
 install:
-  - pip install tox
+  - pip install rstcheck setuptools_git tox tox-pyenv
+  - pyenv root
+  - pyenv local 2.7.15 3.4.9 3.5.5 3.6.7 3.7.1
 script:
   - rstcheck README.rst
   - echo -e "SF_PK = 'Id'" > salesforce/testrunner/local_settings.py
-  - tox -r -e py27-dj111,py36-dj20,py36-dj21,py36-dj110
+  - tox -r 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ cache:
     - $HOME/.pip-cache/
     - $HOME/.pyenv/
 before_install:
+ - pyenv install --list
  - pyenv install --skip-existing 2.7.15
  - pyenv install --skip-existing 3.4.9
  - pyenv install --skip-existing 3.5.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,14 @@ cache:
 before_install:
  - pyenv install --list
  - pyenv install --skip-existing 2.7.15
- - pyenv install --skip-existing 3.4.9
- - pyenv install --skip-existing 3.5.5
- - pyenv install --skip-existing 3.6.7
- - pyenv install --skip-existing 3.7.1
+ - pyenv install --skip-existing 3.4.7
+ - pyenv install --skip-existing 3.5.4
+ - pyenv install --skip-existing 3.6.3
+ - pyenv install --skip-existing 3.7-dev
 install:
   - pip install rstcheck setuptools_git tox tox-pyenv
   - pyenv root
-  - pyenv local 2.7.15 3.4.9 3.5.5 3.6.7 3.7.1
+  - pyenv local 2.7.15 3.4.7 3.5.4 3.6.3 3.7-dev
 script:
   - rstcheck README.rst
   - echo -e "SF_PK = 'Id'" > salesforce/testrunner/local_settings.py


### PR DESCRIPTION
Updated to Ubuntu Xenial. These leverage pyenv and tox-pyenv. Currently still limited on Python 3.7.