### PR TITLE
Fixed If-Unmodifed-Since #210

### DIFF
--- a/coverage_run.sh
+++ b/coverage_run.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # expects that "tox" has been run
-.tox/py36-dj111/bin/coverage run --source salesforce manage.py check >/dev/null
-for x in py27-dj18 py34-dj19 py35-dj110 py36-dj111; do
+COVERAGE=.tox/py37-dj21/bin/coverage
+$COVERAGE run --source salesforce manage.py check >/dev/null
+for x in py27-dj111 py36-dj20 py37-dj21 py35-dj110; do
     .tox/${x}/bin/coverage run -a --source salesforce manage.py inspectdb --database=salesforce >/dev/null
     .tox/${x}/bin/coverage run -a --source salesforce manage.py test salesforce
 done
-COVERAGE=.tox/py36-dj111/bin/coverage
 for x in $(ls -d tests/test_* | sed "s%/%.%"); do
     $COVERAGE run -a --source salesforce manage.py test --settings=$x.settings $x
 done

--- a/salesforce/backend/query.py
+++ b/salesforce/backend/query.py
@@ -601,9 +601,10 @@ class CursorWrapper(object):
                                       for x in pk
                                       ]
                              }
-                import time
-                headers.update({'If-Unmodified-Since': time.strftime('%a, %d %b %Y %H:%M:%S GMT',
-                               (last_mod + datetime.timedelta(seconds=0)).timetuple())})
+                # # Unnecessary code after Salesforce Release Winter '16 Patch 12.0:
+                # import email.utils
+                # headers.update({'If-Unmodified-Since': email.utils.formatdate(
+                #               last_mod.timestamp() + 0, usegmt=True)})
                 _ret = handle_api_exceptions(url, self.session.post, headers=headers, data=json.dumps(post_data), _cursor=self)
             else:
                 # bulk by SOAP

--- a/salesforce/backend/test_helpers.py
+++ b/salesforce/backend/test_helpers.py
@@ -24,3 +24,18 @@ def expectedFailureIf(condition):
         return expectedFailure
     else:
         return lambda func: func
+
+
+def no_soap_decorator(f):
+    """Decorator to not temporarily use SOAP API (Beatbox)"""
+    from functools import wraps
+    import salesforce.backend.driver
+    @wraps(f)
+    def wrapper(*args, **kwds):
+        beatbox_orig = salesforce.backend.driver.beatbox
+        setattr(salesforce.backend.driver, 'beatbox', None)
+        try:
+            return f(*args, **kwds)
+        finally:
+            setattr(salesforce.backend.driver, 'beatbox', beatbox_orig)
+    return wrapper

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -26,6 +26,7 @@ from salesforce import router, DJANGO_110_PLUS, DJANGO_111_PLUS, DJANGO_20_PLUS
 import salesforce
 from ..backend.test_helpers import skip, skipUnless, expectedFailure, expectedFailureIf # test decorators
 from ..backend.test_helpers import current_user, default_is_sf, sf_alias, uid_version as uid
+from ..backend.test_helpers import no_soap_decorator
 
 import logging
 log = logging.getLogger(__name__)
@@ -448,6 +449,8 @@ class BasicSOQLRoTest(TestCase):
             self.assertEqual(len(Contact.objects.filter(account=account)), 2)
         finally:
             account.delete()
+    
+    test_bulk_create_no_soap = no_soap_decorator(test_bulk_create)
 
     @expectedFailureIf(QUIET_KNOWN_BUGS and DJANGO_111_PLUS)
     def test_bulk_update(self):
@@ -467,6 +470,8 @@ class BasicSOQLRoTest(TestCase):
         finally:
             account_0.delete()
             account_1.delete()
+
+    test_bulk_update_no_soap = no_soap_decorator(test_bulk_update)
 
     def test_escape_single_quote(self):
         """Test single quotes in strings used in a filter


### PR DESCRIPTION
- Fixed the bug that depended on the locale.
- Written tests.
- The code "If-Modified-Since" was only due to the upstream bug in Salesforce [Composite Batch API PATCH call returns "entity failed If-Unmodified-Since test on update"...](https://success.salesforce.com/issues_view?id=a1p300000008aYNAAY&title=composite-batch-api-patch-call-returns-entity-failed-if-unmodified-since-test-on-update-but-no-if-unmodified-since-header-in-the-request) and should be removed now because the original required header is now completely ignored.