### PR TITLE
Fixed a very old typo in README

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,127 @@
+Changelog
+=========
+A nicer and more important final change log is
+https://github.com/django-salesforce/django-salesforce/releases
+
+This file CHANGELOG is more raw and especially useful if you want
+to contribute.
+It also is less complete and more oriented to details: in API,
+maybe also internal changes that could have an unexpected effect or
+some undocumented internal code that could yet have been used by
+someone. Not related e.g. to examples and tests,
+but a new feature can be referred by a test name if not documented yet.
+Some items here can be marked as "internal": not ready enough or
+experimental.
+
+
+[0.8] 2019-03-06
+----------------
+
+* Suports: Python 2.7.9+, 3.4 - 3.7, Django 1.10 - 2.2
+  (tested up to 2.2 beta 1)
+
+* Implemented a big part of Python DB API 2.0.
+  Standard DB API is emulated for all ``select`` commands, because it is
+  finally easier and much more stable than to keep the old monkey patch
+  style for new Django versions.
+
+* Added: Linear rows cursor, that is expected by Django, like in other
+  databases, not the cursor with rows like nested multi level dictionaries.
+
+* Added: Bulk methods ``queryset.update()``, ``queryset.delete()``,
+  ``SomeModel.objects.bulk_create([SomeModel(...),...])``.
+  Currently only for 200 rows, in transactions with AllOrNone option.
+  The queryset must contain a restriction. It can be overridden e.g.
+  by ``.filter(pk__gt='')``, that is everytimes true.
+
+* Added: Much better query compiler. Correctness of very complicated queries
+  can be checked now by ``str(my_query_set.query)`` (recommended). A check
+  of WHERE part is usually satisfactory.
+
+* Removed: Extension method ``__len__`` has been removed from RawQuerySet.
+  Consequnece: Function ``len(...)`` can not be applied on ``RawQuerySet``.
+  (The current Django  doesn't cache the results objects of raw queryset.
+  It had no advantage and on the contrary converting the raw query set
+  by ``list(queryset)`` would require two full queries with all data,
+  if ``__len__`` was not removed.)
+
+* New error reporting. Prepared also to a custom error handler to can
+  report more errors, if the block operations could be run without
+  AllOrNone transaction later.
+
+* Fixed: method ``QuerySet.select_related(...)`` (It never worked. Now
+  it works completely.)
+
+* Fixed: ``ManyToMany`` fields. (new, example in
+  test_many2many_relationship_filter)
+
+* Removed: custom method ``simple_select_related()`` (obsoleted by
+  select_related)
+  
+* Changed: All custom error classes has been moved from
+  ``salesforce.backend.driver`` to ``salesforce.dbapi.exceptions``.
+  Very useful class is ``SalesforceError``.
+
+* Changed: Two errors reported by SFDC REST API (ENTITY_IS_DELETED and
+  INVALID_CROSS_REFERENCE_KEY) if a record that has been deleted yet, was
+  tried to be updated or deleted again) were previously intentionally
+  ignored to be compatible with normal SQL. Update is now an error, delete
+  is now a warning, because it is important to easily to clean all objects
+  in tests finally without checking that they were succesfully created.
+  This behavious is open to discussion.
+  (A warning can be easily silenced by configuration naturally.)
+
+* Fixed introspection to work on text formula fields in Salesforce API
+  version 45.0 Spring'19.
+
+* Fixed: Command ``inspectdb`` detects unique firelds by ``unique=True``.
+
+* Fixed: A default command ``inspectdb`` raised exception if ``salesforce``
+  was not in ``INSTALLED_APPS``.
+
+* Changed default ``Meta`` to ``managed=True``. Useful if simple Salesforce
+  models are emulated by another database in fast tests, even without
+  network connectivity. Fixed migrations. #190
+
+* Added support for ``app_label`` config.
+
+Internal:
+
+* Removed: Many internal SOAP API methods (because obsoleted for us by
+  recent REST API methods). Only Lead conversion is still done by SOAP
+  API (beatbox).
+
+* (Discussion: A part of backward compatibility in raw queries could be
+  reimplemented in the next version by a non default method if it will be
+  required, but a current better compatibility with the standard Django
+  is probably more important.)
+
+* Experimental undocumented feature "dynamic models" (started in v0.6.9)
+  can probably have some regressions. Its purpose is to can use Django,
+  mainly in development, if the model doesn't match exactly the SFDC
+  structure with missing or added fields, especially with more databases.
+  Migrations are not expected with it. (simple tests: test_dynamic_fields()
+  and module tests.inspectdb.dependent_model.test)
+
+
+[0.7.2] 2017-05-15
+------------------
+* Added: Support for two timeouts as a tuple (shorter time for connecting,
+  a longer for data in a request)
+
+* Fixed: Updated internal package versioning 0.7+ #184
+
+
+[0.7] 2017-05-01
+----------------
+* Supports: Python 2.7.9+, 3.4 - 3.6, Django 1.8.4 - 1.11
+
+* All SSL/TLS settings and tests has been removed, because TLS 1.0 has been
+  disabled by Salesforce.com and systems with the tested vulnerabilies
+  are unlikely now.
+
+(... not complete)
+
+[0.6.9] 2016-08-12
+------------------
+* Supports: Python 2.7.9+, 3.4 - 3.5, Django 1.7 - 1.10

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,9 +46,9 @@ experimental.
   by ``list(queryset)`` would require two full queries with all data,
   if ``__len__`` was not removed.)
 
-* New error reporting. Prepared also to a custom error handler to can
-  report more errors, if the block operations could be run without
-  AllOrNone transaction later.
+* New error reporting. Prepared also to a custom error handler to be possible
+  to report more errors by block operations, if the would be supported also
+  without AllOrNone transaction later.
 
 * Fixed: method ``QuerySet.select_related(...)`` (It never worked. Now
   it works completely.)
@@ -88,8 +88,8 @@ experimental.
 
 Internal:
 
-* Removed: Many internal SOAP API methods (because obsoleted for us by
-  recent REST API methods). Only Lead conversion is still done by SOAP
+* Removed: Many internal SOAP API methods (because they have obsoleted for
+  us by recent REST API methods). Only Lead conversion is still done by SOAP
   API (beatbox).
 
 * (Discussion: A part of backward compatibility in raw queries could be
@@ -98,7 +98,7 @@ Internal:
   is probably more important.)
 
 * Experimental undocumented feature "dynamic models" (started in v0.6.9)
-  can probably have some regressions. Its purpose is to can use Django,
+  can probably have some regressions. Its purpose is to use Django,
   mainly in development, if the model doesn't match exactly the SFDC
   structure with missing or added fields, especially with more databases.
   Migrations are not expected with it. (simple tests: test_dynamic_fields()

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,8 @@ experimental.
 ----------------
 
 * Suports: Python 2.7.9+, 3.4 - 3.7, Django 1.10 - 2.2
-  (tested up to 2.2 beta 1)
+  (Tested up to the newest 2.2 beta 1 at the release time.
+  It works also with Django 2.2 unchanged.)
 
 * Implemented a big part of Python DB API 2.0.
   Standard DB API is emulated for all ``select`` commands, because it is

--- a/README.rst
+++ b/README.rst
@@ -225,6 +225,12 @@ Advanced usage
    Consequently, the setting ``managed = True`` is related only to an alternate
    non SFDC database configured by ``SF_ALIAS``.)
 
+-  **Exceptions** - Custom exceptions instead of standard Django database
+   exceptions are raised by Django-Salesforce to get more useful information.
+   General exceptions are ``SalesforceError`` or a more general custom
+   ``DatabaseError``. They can be imported from ``salesforce.dbapi.exceptions``
+   if database errors should be handled specifically in your app.
+
 Foreign Key Support
 -------------------
 Foreign key relationships should work as expected, but mapping
@@ -271,6 +277,8 @@ Backwards-incompatible changes
    Completely different implementation of raw queries and cursor that compatible
    with normal databases. (a more backward compatible option can be added if
    it will be required)
+
+   Custom exception classes has been moved to ``salesforce.dbapi.exceptions``.
 
 -  v0.7.2: This is the last code that supports old Django 1.8.4+ and 1.9
 

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ for most uses. It works by integrating with the Django ORM, allowing access to
 the objects in your SFDC instance (Salesforce .com) as if they were in a
 traditional database.
 
-Python 2.7.9+, 3.4 to 3.7, Django 1.10, 1.11, 2.0, 2.1 and 2.2 (tested on beta 1).
+Python 2.7.9+, 3.4 to 3.7, Django 1.10, 1.11, 2.0 to 2.2.
 
 Pre-2.7.9 Python versions don't support the protocol TLS 1.1+ required
 by Salesforce. New PyPy versions compatible with TLS 1.1+ are supported also.

--- a/README.rst
+++ b/README.rst
@@ -169,7 +169,7 @@ Advanced usage
    that most apps require, so the default DB connection to use for Salesforce
    is defined by the ``SALESFORCE_DB_ALIAS`` settings variable. This behavior
    can be also configured by ``DATABASE_ROUTERS``, replacing the use of
-   salesforce.backend.router.ModelRouter.
+   salesforce.router.ModelRouter.
 
 -  **Non SF databases** - If ``SALESFORCE_DB_ALIAS`` is set to a conventional
    database, the tables defined by the SF models will be created by ``migrate``. This

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@
 # command. (The easiest: Simply install tox to python3.5 and run
 # tox from there.)
 minversion = 2.6
-envlist = docs_style, py37-dj21, py36-dj20, py27-dj111, py35-dj110, py36-dj22b, py36-no_django
+envlist = docs_style, py37-dj22, py37-dj21, py36-dj20, py27-dj111, py35-dj110, py36-no_django
 # Explicit combinations can be tested even though are not listed in ALL:
 # `tox -e py35-dj110,py35-djdev`
 # `tox -e docs`   # test documentation
@@ -27,7 +27,7 @@ deps =
     dj111: Django~=1.11.17
     dj20: Django~=2.0.9
     dj21: Django~=2.1.4
-    dj22b: Django~=2.2b1
+    dj22: Django~=2.2
     py27: mock
     pylint: pylint
     pylint: pylint-django
@@ -35,7 +35,7 @@ deps =
     djdev: https://github.com/django/django/archive/master.zip
     # local copy of django/origin master
     # wget https://github.com/django/django/archive/master.zip -O django-22-dev.zip
-    djdevlocal: django-22-dev.zip
+    # djdevlocal: django-22-dev.zip
     coverage
     # This Beatbox version works with Python 3 and 2.
     # Be hopeful, it will be soon in official repositories.

--- a/tox.ini
+++ b/tox.ini
@@ -79,7 +79,7 @@ deps =
     rstcheck
 commands =
     flake8
-    rstcheck README.rst
+    rstcheck README.rst CHANGELOG.rst
 
 # === lint configurations (not tests) ===
 [flake8]


### PR DESCRIPTION
This was a typo in an old text from 2014, but the Model has been in salesforce.router since prehistory.