### PR TITLE
Model ids are now stored as Text when generating the tables of a local database

### DIFF
--- a/salesforce/fields.py
+++ b/salesforce/fields.py
@@ -46,6 +46,9 @@ class SalesforceAutoField(fields.AutoField):
     """
     description = _("Text")
 
+    def get_internal_type(self):
+        return "TextField"
+
     default_error_messages = {
         'invalid': _('This value must be a valid Salesforce ID.'),
     }


### PR DESCRIPTION
From Issue #231

I'm running into a problem when testing a salesforce database locally.
I believe the tables in the local database has been generated with an integer type for the ID field

For example:

```
a = Account(id="abc123abc123abc", ...)
a.save()
```
Would fail, as id has a type mismatch, and is expecting an integer

I was writing some tests using a Factory to populate the local db, something like this:
```
class SFAccountFactory(factory.django.DjangoModelFactory):
    class Meta:
        model = 'eiq_salesforce.Account'

    name = Faker('company')
    description = Faker('text')
    website = Faker('url')
```
But I have some code elsewhere that allows users to search for SF objects by ID, and it ensures that the ID is either 15 or 18 characters long, which these autogenerated IDs were not. So it was raising errors, and my tests could not pass.

So then I added an id field to the factory, to make it for sure 18 chars long
```
def get_standardized_sf_id(sf_id):
    # ensure ID is salesforce 18 char case insensitive id
    # https://help.salesforce.com/articleView?id=000274977&type=1&language=en_US

    suffix = ""
    for i in range(3):
        loop = 0
        for position in range(5):
            current = sf_id[i * 5 + position]
            if current.isupper():
                loop += 1 << position
        suffix += "ABCDEFGHIJKLMNOPQRSTUVWXYZ012345"[loop]
    sf_id = sf_id[:15] + suffix
    return sf_id


class SFAccountFactory(factory.django.DjangoModelFactory):
    id = factory.Sequence(lambda n: get_standardized_sf_id('%015d' % n))
    ...
```

`get_standardized_sf_id` just ensures that the ID is following the same algorithm salesforce  uses to make the IDs case insensitive.

This then started throwing errors because it was trying to assign a string to an integer field in the database.

I believe this is because the SalesforceAutoField, as given to the id field in the SalesforceModel has not overriden the get_internal_type() method, and is defaulting to the integer type, of the parent class AutoField

```
class SalesforceAutoField(fields.AutoField):
    """
    An AutoField that works with Salesforce primary keys.

    It is used by SalesforceModel as a custom primary key. It doesn't convert
    its value to int.
    """
    description = _("Text")

    def get_internal_type(self):
        return "TextField"

    default_error_messages = {
        'invalid': _('This value must be a valid Salesforce ID.'),
    }

    def to_python(self, value):
        ...
```

I was not able to run the tests myself, I do not have access to a sandbox api.
Was hoping to use travis here.