### PR TITLE
Support for Salesforce 47.0 Winter '20 and Django 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ install:
 script:
   - rstcheck README.rst
   - echo -e "SF_PK = 'Id'" > salesforce/testrunner/local_settings.py
-  - tox -r -e py36-dj30a,py27-dj111,py36-dj20,py36-dj21,py35-dj110
+  - tox -r -e py36-dj30b,py27-dj111,py36-dj20,py36-dj21,py35-dj110

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ install:
 script:
   - rstcheck README.rst
   - echo -e "SF_PK = 'Id'" > salesforce/testrunner/local_settings.py
-  - tox -r -e py27-dj111,py36-dj20,py36-dj21,py35-dj110
+  - tox -r -e py36-dj30a,py27-dj111,py36-dj20,py36-dj21,py35-dj110

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,15 @@ Unreleased
 
 * Fixed: test setUpClass to can run tests on an empty Salesforce database.
 
+* Fixed: ``TimeField.save()`` regression on BusinessHours object. (Salesforce 47.0
+  Winter '20 started to apply a default time shift by Organization time zone on
+  TimeField.)
+
+* Fixed inspectbd to ignore some new objects in Salesforce 47.0 Winter '20
+  that are not a table.
+
+* Updated for Django 3.0 beta 1.
+
 
 [0.8.1] 2019-05-22
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -287,6 +287,6 @@ Backwards-incompatible changes
 -  v0.6.1: This is the last code that supports old Django 1.4, 1.5, 1.6.
 
 -  v0.5: The name of primary key is currently ``'id'``. The backward compatible
-   behaviour for code created before v0.5 can be reached by settings ``SF_PK='Id'``.
+   behavior for code created before v0.5 can be reached by settings ``SF_PK='Id'``.
 
 

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ for most uses. It works by integrating with the Django ORM, allowing access to
 the objects in your SFDC instance (Salesforce .com) as if they were in a
 traditional database.
 
-Python 2.7.9+, 3.4 to 3.7, Django 1.10, 1.11, 2.0 to 2.2.
+Python 2.7.9+, 3.4 to 3.8, Django 1.10, 1.11, 2.0 to 2.2 (and 3.0 beta 1).
 
 Pre-2.7.9 Python versions don't support the protocol TLS 1.1+ required
 by Salesforce. New PyPy versions compatible with TLS 1.1+ are supported also.

--- a/salesforce/__init__.py
+++ b/salesforce/__init__.py
@@ -29,5 +29,5 @@ log = logging.getLogger(__name__)
 # >>> import salesforce
 # >>> setattr(salesforce, 'API_VERSION', '37.0')
 
-API_VERSION = '45.0'  # Spring '19
-# API_VERSION = '46.0'  # Summer '19
+API_VERSION = '46.0'  # Summer '19
+# API_VERSION = '47.0'  # Winter '20

--- a/salesforce/backend/__init__.py
+++ b/salesforce/backend/__init__.py
@@ -37,6 +37,7 @@ DJANGO_111_PLUS = django.VERSION[:2] >= (1, 11)
 DJANGO_20_PLUS = django.VERSION[:2] >= (2, 0)
 DJANGO_21_PLUS = django.VERSION[:2] >= (2, 1)
 DJANGO_22_PLUS = django.VERSION[:2] >= (2, 2)
+DJANGO_30_PLUS = django.VERSION[:2] >= (3, 0)
 is_dev_version = django.VERSION[3:] and re.match('(alpha|beta|rc)', django.VERSION[3])
 if django.VERSION[:2] < (1, 10) or django.VERSION[:2] > (2, 2) and not is_dev_version:
     # Usually three or more blocking issues can be expected by every

--- a/salesforce/backend/__init__.py
+++ b/salesforce/backend/__init__.py
@@ -39,7 +39,7 @@ DJANGO_21_PLUS = django.VERSION[:2] >= (2, 1)
 DJANGO_22_PLUS = django.VERSION[:2] >= (2, 2)
 DJANGO_30_PLUS = django.VERSION[:2] >= (3, 0)
 is_dev_version = django.VERSION[3:] and re.match('(alpha|beta|rc)', django.VERSION[3])
-if django.VERSION[:2] < (1, 10) or django.VERSION[:2] > (2, 2) and not is_dev_version:
+if django.VERSION[:2] < (1, 10) or django.VERSION[:2] > (3, 0) and not is_dev_version:
     # Usually three or more blocking issues can be expected by every
     # new major Django version. Strict check before support is better.
 

--- a/salesforce/backend/features.py
+++ b/salesforce/backend/features.py
@@ -2,6 +2,7 @@
 Database features  (like django.db.backends.*.features)
 """
 from django.db.backends.base.features import BaseDatabaseFeatures
+from salesforce.backend import DJANGO_30_PLUS
 
 
 class DatabaseFeatures(BaseDatabaseFeatures):
@@ -10,8 +11,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     """
     allows_group_by_pk = True
     supports_unspecified_pk = False
-    can_return_id_from_insert = True
-    can_return_ids_from_bulk_insert = True
     has_bulk_insert = True
     uses_savepoints = False
 
@@ -28,8 +27,13 @@ class DatabaseFeatures(BaseDatabaseFeatures):
 
     # features for Django 3.0
     can_create_inline_fk = False
-    can_return_columns_from_insert = True
-    can_return_rows_from_bulk_insert = True  # pylint:disable=invalid-name
+
+    if DJANGO_30_PLUS:
+        can_return_columns_from_insert = True
+        can_return_rows_from_bulk_insert = True  # pylint:disable=invalid-name
+    else:
+        can_return_id_from_insert = True
+        can_return_ids_from_bulk_insert = True
 
     # TODO These options are the only from Django 2.2 that can be useful
     #      for something implemented here in future: Atomic, SFDX, Explain

--- a/salesforce/backend/introspection.py
+++ b/salesforce/backend/introspection.py
@@ -38,6 +38,8 @@ PROBLEMATIC_OBJECTS = [
     'LogoutEventStream',  # new in API 46.0 Summer '19
     'AsyncOperationEvent',  # new in API 46.0 Summer '19
     'AsyncOperationStatus',  # new in API 46.0 Summer '19
+    'DatasetExportEvent', 'VisibilityUpdateEvent',  # new in API 46.0 Summer '19 - missing 'Id'
+    'FlowExecutionErrorEvent',  # new in API 47.0 Winter '20 - missing 'Id'
 ]
 
 # these global variables are for `salesforce.management.commands.inspectdb`
@@ -103,7 +105,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             self._table_list_cache = response.json(object_pairs_hook=OrderedDict)
             self._table_list_cache['sobjects'] = [
                 x for x in self._table_list_cache['sobjects']
-                if x['name'] not in PROBLEMATIC_OBJECTS
+                if x['name'] not in PROBLEMATIC_OBJECTS and not x['name'].endswith('ChangeEvent')
             ]
         return self._table_list_cache
 

--- a/salesforce/backend/operations.py
+++ b/salesforce/backend/operations.py
@@ -12,6 +12,7 @@ import itertools
 import django.db.backends.utils
 from django.utils.deconstruct import deconstructible
 from django.db.backends.base.operations import BaseDatabaseOperations
+from salesforce.backend import DJANGO_30_PLUS
 
 BULK_BATCH_SIZE = 200
 
@@ -55,11 +56,24 @@ class DatabaseOperations(BaseDatabaseOperations):
     def last_insert_id(self, cursor, table_name, pk_name):
         return cursor.lastrowid
 
-    def fetch_returned_insert_id(self, cursor):
-        return cursor.lastrowid
+    if DJANGO_30_PLUS:
 
-    def fetch_returned_insert_ids(self, cursor):
-        return cursor.lastrowid
+        def fetch_returned_insert_columns(self, cursor):
+            return [cursor.lastrowid]
+
+        def fetch_returned_insert_rows(self, cursor):
+            return [[x] for x in cursor.lastrowid]
+
+        def return_insert_columns(self, fields):
+            return '', ()  # dummy result
+
+    else:
+
+        def fetch_returned_insert_id(self, cursor):
+            return cursor.lastrowid
+
+        def fetch_returned_insert_ids(self, cursor):
+            return cursor.lastrowid
 
     # A method max_in_list_size(self) would be not a solution, because it is
     # restricted by a maximal size of SOQL.

--- a/salesforce/backend/utils.py
+++ b/salesforce/backend/utils.py
@@ -196,7 +196,7 @@ class CursorWrapper(object):
                 # SELECT
                 self.rowcount = data['totalSize']
             # a successful INSERT query, return after getting PK
-            elif('success' in data and 'id' in data):
+            elif 'success' in data and 'id' in data:
                 self.lastrowid = data['id']
                 return
             elif 'compositeResponse' in data:

--- a/salesforce/dbapi/driver.py
+++ b/salesforce/dbapi/driver.py
@@ -792,7 +792,7 @@ register_conversion(str,             json_conv=lambda o: o,             sql_conv
 register_conversion(bool,            json_conv=lambda s: str(s).lower())
 register_conversion(datetime.date,   json_conv=lambda d: datetime.date.strftime(d, "%Y-%m-%d"))
 register_conversion(datetime.datetime, json_conv=date_literal)
-register_conversion(datetime.time,   json_conv=lambda d: datetime.time.strftime(d, "%H:%M:%S.%f"))
+register_conversion(datetime.time,   json_conv=lambda d: datetime.time.strftime(d, "%H:%M:%S.%fZ"))
 register_conversion(decimal.Decimal, json_conv=float, subclass=True)
 # the type models.Model is registered from backend, because it is a Django type
 # pylint:enable=bad-whitespace

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -957,7 +957,7 @@ class BasicSOQLRoTest(TestCase, LazyTestMixin):
         # with self.lazy_assert_n_requests(2):  # problem - Why too much requests?
         # raw query must contain the primary key (with the right capitalization, currently)
         with self.lazy_assert_n_requests(1):  # TODO why two requests?
-            ret = list(Contact.objects.raw("select Id from Contact"))
+            ret = list(Contact.objects.raw("select Id from Contact limit 2000"))
         with self.lazy_assert_n_requests(1):
             last_name = ret[0].last_name
         self.assertTrue(last_name and 'last' not in last_name.lower())

--- a/tests/inspectdb/slow_test.py
+++ b/tests/inspectdb/slow_test.py
@@ -36,7 +36,7 @@ def run():
     n_tables = n_read = n_no_data = n_read_errors = n_write = n_write_errors = 0
     sf.cursor()  # this must connect manually  # TODO fix it automatically if reasonable
     for tab in sf.introspection.table_list_cache['sobjects']:
-        if tab['retrieveable'] and not tab['name'] in (
+        if tab['retrieveable'] and not tab['name'].endswith('ChangeEvent') and not tab['name'] in (
                 # These require specific filters (descried in their error messages)
                 'CollaborationGroupRecord', 'ContentFolderMember', 'ContentFolderItem',
                 'ContentDocumentLink', 'Idea', 'IdeaComment', 'UserProfileFeed',
@@ -94,7 +94,7 @@ def run():
                     # A special user of type user_type='AutomatedProcess' exists in Users
                     # since API 41.0 Winter'18.
                     # That user account can not be saved because it has an invalid email.
-                    'User',
+                    'User', 'UserLogin',
             ):
                 stdout.write('(write) ')
                 try:

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@
 # command. (The easiest: Simply install tox to python3.5 and run
 # tox from there.)
 minversion = 2.6
-envlist = docs_style, py37-dj30a, py37-dj22, py37-dj21, py36-dj20, py27-dj111, py35-dj110, py36-no_django
+envlist = docs_style, py38-dj30b, py37-dj22, py37-dj21, py36-dj20, py27-dj111, py35-dj110, py36-no_django
 # Explicit combinations can be tested even though are not listed in ALL:
 # `tox -e py35-dj110,py35-djdev`
 # `tox -e docs`   # test documentation
@@ -20,6 +20,7 @@ basepython =
     py35: python3.5
     py36: python3.6
     py37: python3.7
+    py38: python3.8
     pypy: pypy
     pypy3: pypy3
 deps =
@@ -33,7 +34,7 @@ deps =
     py34: typing
     pylint: pylint
     pylint: pylint-django
-    dj30a: https://www.djangoproject.com/download/3.0a1/tarball/
+    dj30b: https://www.djangoproject.com/download/3.0b1/tarball/
     djdev: https://github.com/django/django/archive/master.zip
     # local copy of django/origin master
     # wget https://github.com/django/django/archive/master.zip -O django-22-dev.zip

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ deps =
     py34: typing
     pylint: pylint
     pylint: pylint-django
-    # dj22: https://www.djangoproject.com/download/2.2rc1/tarball/
+    dj30a: https://www.djangoproject.com/download/3.0a1/tarball/
     djdev: https://github.com/django/django/archive/master.zip
     # local copy of django/origin master
     # wget https://github.com/django/django/archive/master.zip -O django-22-dev.zip

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@
 # command. (The easiest: Simply install tox to python3.5 and run
 # tox from there.)
 minversion = 2.6
-envlist = docs_style, py37-dj22, py37-dj21, py36-dj20, py27-dj111, py35-dj110, py36-no_django
+envlist = docs_style, py37-dj30a, py37-dj22, py37-dj21, py36-dj20, py27-dj111, py35-dj110, py36-no_django
 # Explicit combinations can be tested even though are not listed in ALL:
 # `tox -e py35-dj110,py35-djdev`
 # `tox -e docs`   # test documentation


### PR DESCRIPTION
I suggest a new release soon.

this PR:

- Fix a small bug with Salesforce Winter '20 (Currently present only in preview sanboxes, but coming very soon) It is quite an important bug, but the impact is only for a `BusinessHours` object if it would be updated by Django. It is the only object where the `TimeField` is used or can be used.

- Fix django-salesforce for Django 3.0 (currently 3.0 alpha 1) Problems were only with `insert` command. It is as well the only important change related to database in Release notes 3.0.

I expect only documentation edit and release notes before the new release.