### PR TITLE
DefaultedOnCreate, static typing etc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ htmlcov/
 coverage_html/
 log
 tests/inspectdb/models.py
+tests/inspectdb/dependent_model/models_template.py
 salesforce/packages/
 venv
 tests/x_*/

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,12 @@ cache:
 before_install:
  - git clone git://github.com/pyenv/pyenv-update.git $(pyenv root)/plugins/pyenv-update
  - pyenv install --list
- - pyenv install --skip-existing 2.7.15
  - pyenv install --skip-existing 3.5.4
  - pyenv install --skip-existing 3.6.7
 install:
   - pip install rstcheck setuptools_git tox tox-pyenv
-  - pyenv local 2.7.15 3.5.4 3.6.7
+  - pyenv local 3.5.4 3.6.7
 script:
   - rstcheck README.rst
   - echo -e "SF_PK = 'Id'" > salesforce/testrunner/local_settings.py
-  - tox -r -e py36-dj30,py27-dj111,py36-dj20,py36-dj21,py35-dj22,debug_toolbar
+  - tox -r -e py36-dj30,py36-dj22,py35-dj111,debug_toolbar

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,8 +14,8 @@ Some items here can be marked as "internal": not ready enough or
 experimental.
 
 
-Unreleased
-----------
+[1.0] 2020-05-07
+----------------
 * Remove: Support for Django 1.10
 * Remove: Support for Python 2.7, 3.4
 * Add: Support for Python 3.9 (alpha 5)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,12 +18,39 @@ Unreleased
 ----------
 * Remove: Support for Django 1.10
 * Remove: Support for Python 2.7, 3.4
+* Add: Support for Python 3.9 (alpha 5)
+* Add: Preliminary support for Django 3.1-dev (development snaphot 2020-04-21)
+* Fix: Fixed all hidden deprecation warnings. (related removed old versions)
+* Fix: .annotate() method can use GROUP BY if Django >= 2.1
+       example queryset.order_by().values('account_id').annotate(cnt=Count('id'))
+* Fix: DefaultedOnCreate() and DEFAULTED_ON_CREATE is now transparent for
+       other code. It has a surrogate normal value and it is never saved #213
+* Add: Warning if a value DEFAULTED_ON_CREATE is tried to be saved again without
+       refreshing the real value.
 * Fix: Support for Django Debug Toolbar - including EXPLAIN commend
+* Fix: Consistent output of inspectdb with db_column on every field.
+       The old behavior with ``custom=`` parameter and minimalistic db_column
+       can be turn on by ``--concise-db-column`` option. #250
 * Fix: Export attributes "verbose_name", "help_text" and "default=DEFAULTED_ON_CREATE"
-  also for ForeignKey by inspectdb.
-* Fix: Don't export DEFAULTED_ON_CREATE excessively for not createable fields.
-* Fix: Error handling in bulk delete
-* Fixed: SomeModel.objects.all().delete()
+       also for ForeignKey by inspectdb.
+* Fix: Not to export DEFAULTED_ON_CREATE excessively for not createable fields.
+* Fix: Error handling in bulk delete()
+* Fix: SomeModel.objects.all().delete()
+* Fix: Wildcard search with characters "_" and "%". #254
+* Fix: Accept a manually added AutoField in models.
+* Fix: Close correctly all SSL sockets before dropped. (minor)
+* Fix: Lazy test helper fixed for Python >= 3.8 (lazy: exception can be tested later
+       then the fail was detected. It uses two tracebacks.
+       e.g. ``with lazy_assert_n_requests(n)``: check that the optimal number
+       of requests was used if everything critical was OK and show the first
+       suboptimal command-line.)
+* Add: Bulk update limited to 200 objects: bulk_update_small()
+* Add: Static typing by Mypy. Can validate user code that correspondd to the user data model.
+        with SalesforceModel (requires also installed django-salesforce-stubs)
+* Update: Salesforce 48.0 Spring '20 (no fix)
+* Add: Raw cursor with fields dict: ``connection.cursor(name='dict')``
+* Add: Internal module mocksf is used in tests/debugging for record or replay of
+       raw Salesforce requests/responses.
 
 
 [0.9] 2019-11-04

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,8 +16,8 @@ experimental.
 
 Unreleased
 ----------
-* Remove: Support for Django 1.10 (incompatible)
-* Remove: Support for Python 3.4 (not tested anymore)
+* Remove: Support for Django 1.10
+* Remove: Support for Python 2.7, 3.4
 * Fix: Support for Django Debug Toolbar - including EXPLAIN commend
 * Fix: Export attributes "verbose_name", "help_text" and "default=DEFAULTED_ON_CREATE"
   also for ForeignKey by inspectdb.
@@ -115,7 +115,7 @@ Unreleased
 
 * Removed: custom method ``simple_select_related()`` (obsoleted by
   select_related)
-  
+
 * Changed: All custom error classes has been moved from
   ``salesforce.backend.driver`` to ``salesforce.dbapi.exceptions``.
   Very useful class is ``SalesforceError``.

--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,7 @@ the objects in your SFDC instance (Salesforce .com) as if they were in a
 traditional database.
 
 Python 3.5.2 to 3.8, Django 1.11, 2.0 to 2.2 and 3.0.
+(Tested also with Python 3.9.0a5)
 
 
 Quick Start

--- a/README.rst
+++ b/README.rst
@@ -49,9 +49,14 @@ Quick Start
        New.
      - Click "Enable OAuth Settings" in API, then select "Access and manage
        your data (api)" from available OAuth Scopes.
-     - Other red marked fields must be filled, but are not relevant for Django.
+     - Other red marked fields must be filled, but are not relevant for Django
+       with password authentication. (For example a "Callback URL" can be an
+       URL that doesn't exist, but that is under your control, for the case that
+       you accidentally activate other OAuth mode later.)
    * ``USER`` is the username used to connect.
    * ``PASSWORD`` is a concatenation of the user's password and security token.
+     Security token can be set by My Settings / Personal / Reset My Security Token
+     or an new token is received by email after every password change.
      Security token can be omitted if the local IP address has been
      whitelisted in Security Controls / Network Access.
    * ``HOST`` is ``https://test.salesforce.com`` to access a sandbox, or

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ django-salesforce
 .. image:: https://badge.fury.io/py/django-salesforce.svg
    :target: https://pypi.python.org/pypi/django-salesforce
 
-.. image:: https://img.shields.io/badge/Python-3.5%2C%203.6%2C%203.7-%2C%203.8-brightgreen.svg
+.. image:: https://img.shields.io/badge/Python-3.5%3C%203.6%2C%203.7-%2C%203.8-brightgreen.svg
    :target: https://www.python.org/
 
 .. image:: https://img.shields.io/badge/Django-1.11%2C%202.0%2C%202.1%2C%202.2%2C%203.0-blue.svg
@@ -19,7 +19,7 @@ for most uses. It works by integrating with the Django ORM, allowing access to
 the objects in your SFDC instance (Salesforce .com) as if they were in a
 traditional database.
 
-Python 3.5.2 to 3.8, Django 1.11, 2.0 to 2.2 and 3.0.
+Python 3.5.3 to 3.8, Django 1.11, 2.0 to 2.2 and 3.0.
 (Tested also with Python 3.9.0a5)
 
 

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ django-salesforce
 .. image:: https://badge.fury.io/py/django-salesforce.svg
    :target: https://pypi.python.org/pypi/django-salesforce
 
-.. image:: https://img.shields.io/badge/Python-2.7.9%2B%2C%203.5%2C%203.6%2C%203.7-brightgreen.svg
+.. image:: https://img.shields.io/badge/Python-3.5%2C%203.6%2C%203.7-%2C%203.8-brightgreen.svg
    :target: https://www.python.org/
 
 .. image:: https://img.shields.io/badge/Django-1.11%2C%202.0%2C%202.1%2C%202.2%2C%203.0-blue.svg
@@ -19,10 +19,8 @@ for most uses. It works by integrating with the Django ORM, allowing access to
 the objects in your SFDC instance (Salesforce .com) as if they were in a
 traditional database.
 
-Python 2.7.9+, 3.5 to 3.8, Django 1.11, 2.0 to 3.0.
+Python 3.5.2 to 3.8, Django 1.11, 2.0 to 2.2 and 3.0.
 
-Pre-2.7.9 Python versions don't support the protocol TLS 1.1+ required
-by Salesforce. New PyPy versions compatible with TLS 1.1+ are supported also.
 
 Quick Start
 -----------
@@ -269,6 +267,7 @@ here are the potential pitfalls and unimplemented operations:
 Backwards-incompatible changes
 ------------------------------
 
+-  v0.9: This is the last version that suports Django 1.10 and Python 2.7 and 3.4
 -  v0.8: The default Meta option if now ``managed = True``, which is an unimportant
    change for Salesforce databases (see about Migrations above).
 

--- a/coverage_run.sh
+++ b/coverage_run.sh
@@ -2,7 +2,7 @@
 # expects that "tox" has been run
 COVERAGE=.tox/py37-dj21/bin/coverage
 $COVERAGE run --source salesforce manage.py check >/dev/null
-for x in py27-dj111 py36-dj20 py37-dj21 py38-dj30; do
+for x in py35-dj111 py36-dj20 py37-dj21 py38-dj30; do
     .tox/${x}/bin/coverage run -a --source salesforce manage.py inspectdb --database=salesforce >/dev/null
     .tox/${x}/bin/coverage run -a --source salesforce manage.py test salesforce
 done

--- a/mypy.ini
+++ b/mypy.ini
@@ -5,5 +5,8 @@ plugins =
 [mypy.plugins.django-stubs]
 django_settings_module = "salesforce.testrunner.settings"
 
+[mypy-salesforce.fields]
+disallow_any_generics = False
+
 [mypy-salesforce.testrunner.example.migrations.*,tests.*.migrations.*]
 ignore_errors = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,9 @@
+[mypy]
+plugins =
+    mypy_django_plugin.main
+
+[mypy.plugins.django-stubs]
+django_settings_module = "salesforce.testrunner.settings"
+
+[mypy-salesforce.testrunner.example.migrations.*,tests.*.migrations.*]
+ignore_errors = True

--- a/pylintrc
+++ b/pylintrc
@@ -62,7 +62,6 @@ confidence=
 disable=
     fixme,  # only the "TODO" word shoud be used here for easy grep
     missing-docstring,
-    useless-object-inheritance,  # class ...(object):  due to Python2 compatibility
     inconsistent-return-statements,  # similar style to Django
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 simplejson>=2.5.0
 pytz>=2012c
 requests>=2.4.0
-six
 # Django requirement is specified in setup.py,
 # because pip doesn't accept double requirement in tests.

--- a/salesforce/__init__.py
+++ b/salesforce/__init__.py
@@ -29,4 +29,4 @@ log = logging.getLogger(__name__)
 # >>> import salesforce
 # >>> setattr(salesforce, 'API_VERSION', '37.0')
 
-API_VERSION = '47.0'  # Winter '20
+API_VERSION = '48.0'  # Spring '20

--- a/salesforce/__init__.py
+++ b/salesforce/__init__.py
@@ -16,7 +16,7 @@ from salesforce.dbapi.exceptions import (  # NOQA pylint:disable=unused-import,u
     IntegrityError as IntegrityError, DatabaseError as DatabaseError, SalesforceError as SalesforceError,
 )
 
-__version__ = "0.9"
+__version__ = "1.0"
 
 log = logging.getLogger(__name__)
 

--- a/salesforce/apps.py
+++ b/salesforce/apps.py
@@ -1,0 +1,10 @@
+"""This file is useful only if 'salesforce' is a duplicit name in Django registry
+
+then put a string 'salesforce.apps.SalesforceDb' instead of simple 'salesforce'
+"""
+from django.apps import AppConfig
+
+
+class SalesforceDb(AppConfig):
+    name = 'salesforce'
+    label = 'salesforce_db'

--- a/salesforce/auth.py
+++ b/salesforce/auth.py
@@ -168,7 +168,7 @@ class SalesforcePasswordAuth(SalesforceAuth):
         settings_dict = self.settings_dict
         url = ''.join([settings_dict['HOST'], '/services/oauth2/token'])
 
-        log.info("attempting authentication to %s", settings_dict['HOST'])
+        log.info("authentication to %s as %s", settings_dict['HOST'], settings_dict['USER'])
         self._session.mount(settings_dict['HOST'], HTTPAdapter(max_retries=get_max_retries()))
         auth_params = {
             'grant_type':    'password',
@@ -190,9 +190,7 @@ class SalesforcePasswordAuth(SalesforceAuth):
                     ).digest()
                 )
             ).decode('ascii')
-            if calc_signature == response_data['signature']:
-                log.info("successfully authenticated %s", settings_dict['USER'])
-            else:
+            if calc_signature != response_data['signature']:
                 raise IntegrityError('Invalid auth signature received')
         else:
             raise SalesforceAuthError("oauth failed: %s: %s" % (settings_dict['USER'], response.text))

--- a/salesforce/auth.py
+++ b/salesforce/auth.py
@@ -8,11 +8,7 @@
 """
 oauth login support for the Salesforce API
 
-All data are in ascii. Therefore the type str is good for both Python 2.7
-and 3.4+. (The type str ascii is automatically adjusted to unicode in
-Python 2, if necessary, but the unicode ascii could force an automatic
-faulting conversion of other non-ascii str to unicode.)
-Accepted parameters are both str or unicode in Python 2.
+All data are ascii str.
 """
 
 import base64
@@ -182,8 +178,7 @@ class SalesforcePasswordAuth(SalesforceAuth):
         }
         response = self._session.post(url, data=auth_params)
         if response.status_code == 200:
-            # prefer str in Python 2 due to other API
-            response_data = {str(k): str(v) for k, v in response.json().items()}
+            response_data = response.json()
             # Verify signature (not important for this auth mechanism)
             calc_signature = (
                 base64.b64encode(

--- a/salesforce/auth.py
+++ b/salesforce/auth.py
@@ -186,7 +186,7 @@ class SalesforcePasswordAuth(SalesforceAuth):
         }
         response = self._session.post(url, data=auth_params)
         if response.status_code == 200:
-            response_data = response.json()
+            response_data = response.json()  # type: Dict[str, str]
             # Verify signature (not important for this auth mechanism)
             calc_signature = (
                 base64.b64encode(

--- a/salesforce/auth.py
+++ b/salesforce/auth.py
@@ -174,7 +174,9 @@ class SalesforcePasswordAuth(SalesforceAuth):
         url = ''.join([settings_dict['HOST'], '/services/oauth2/token'])
 
         log.info("authentication to %s as %s", settings_dict['HOST'], settings_dict['USER'])
-        self._session.mount(settings_dict['HOST'], HTTPAdapter(max_retries=get_max_retries()))
+        if settings_dict['HOST'] not in self._session.adapters:
+            # a repeated mount to the same prefix would cause a warning about unclosed SSL socket
+            self._session.mount(settings_dict['HOST'], HTTPAdapter(max_retries=get_max_retries()))
         auth_params = {
             'grant_type':    'password',
             'client_id':     settings_dict['CONSUMER_KEY'],

--- a/salesforce/auth.py
+++ b/salesforce/auth.py
@@ -11,7 +11,7 @@ oauth login support for the Salesforce API
 All data are ascii str.
 """
 
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 import base64
 import hashlib
 import hmac
@@ -75,7 +75,8 @@ class SalesforceAuth(AuthBase):
     http://docs.python-requests.org/en/latest/user/advanced/#custom-authentication
     """
 
-    def __init__(self, db_alias: str, settings_dict: Dict = None, _session: requests.Session = None):
+    def __init__(self, db_alias: str, settings_dict: Optional[Dict[str, Any]] = None,
+                 _session: Optional[requests.Session] = None) -> None:
         """
         Set values for authentication
             Params:
@@ -124,7 +125,7 @@ class SalesforceAuth(AuthBase):
             del oauth_data[self.db_alias]
         self.dynamic = None
 
-    def __call__(self, r):
+    def __call__(self, r: requests.PreparedRequest) -> requests.PreparedRequest:
         """Standard auth hook on the "requests" request r"""
         access_token = self.get_auth()['access_token']
         r.headers['Authorization'] = 'OAuth %s' % access_token
@@ -143,7 +144,7 @@ class SalesforceAuth(AuthBase):
     def instance_url(self) -> str:
         return self.get_auth()['instance_url']
 
-    def dynamic_start(self, access_token: str, instance_url: str = None, **kw):
+    def dynamic_start(self, access_token: str, instance_url: str = '', **kw: Any) -> None:
         """
         Set the access token dynamically according to the current user.
 

--- a/salesforce/auth.py
+++ b/salesforce/auth.py
@@ -11,6 +11,7 @@ oauth login support for the Salesforce API
 All data are ascii str.
 """
 
+from typing import Dict
 import base64
 import hashlib
 import hmac
@@ -33,7 +34,7 @@ oauth_lock = threading.Lock()
 # The static "oauth_data" is useful for efficient static authentication with
 # multithread server, whereas the thread local data in connection.sf_session.auth
 # are necessary if dynamic auth is used.
-oauth_data = {}
+oauth_data = {}  # type: Dict[str, Dict[str, str]]
 
 
 class SalesforceAuth(AuthBase):

--- a/salesforce/backend/__init__.py
+++ b/salesforce/backend/__init__.py
@@ -37,6 +37,7 @@ DJANGO_20_PLUS = django.VERSION[:2] >= (2, 0)
 DJANGO_21_PLUS = django.VERSION[:2] >= (2, 1)
 DJANGO_22_PLUS = django.VERSION[:2] >= (2, 2)
 DJANGO_30_PLUS = django.VERSION[:2] >= (3, 0)
+DJANGO_31_PLUS = django.VERSION[:2] >= (3, 1)  # still only a development version exists
 is_dev_version = django.VERSION[3:] and re.match('(alpha|beta|rc)', django.VERSION[3])
 if django.VERSION[:2] < (1, 11) or django.VERSION[:2] > (3, 0) and not is_dev_version:
     raise ImportError("Django version between 1.11 and 3.0 is required "

--- a/salesforce/backend/__init__.py
+++ b/salesforce/backend/__init__.py
@@ -39,13 +39,13 @@ DJANGO_22_PLUS = django.VERSION[:2] >= (2, 2)
 DJANGO_30_PLUS = django.VERSION[:2] >= (3, 0)
 is_dev_version = django.VERSION[3:] and re.match('(alpha|beta|rc)', django.VERSION[3])
 if django.VERSION[:2] < (1, 11) or django.VERSION[:2] > (3, 0) and not is_dev_version:
+    raise ImportError("Django version between 1.11 and 3.0 is required "
+                      "for this django-salesforce.")
     # Usually three or more blocking issues can be expected by every
     # new major Django version. Strict check before support is better.
 
     # New Django development versions are enabled without any restriction, but
     # new stable Django versions must be verified before they can be enabled here.
-    raise ImportError("Django version between 1.11 and 2.2 is required "
-                      "for this django-salesforce.")
 
 
 log = logging.getLogger(__name__)

--- a/salesforce/backend/base.py
+++ b/salesforce/backend/base.py
@@ -9,6 +9,8 @@
 Salesforce database backend for Django.  (like django,db.backends.*.base)
 """
 
+from urllib.parse import urlparse
+
 from django.core.exceptions import ImproperlyConfigured
 from django.conf import settings
 from django.db.backends.base.base import BaseDatabaseWrapper
@@ -24,11 +26,6 @@ from salesforce.backend.schema import DatabaseSchemaEditor
 from salesforce.backend.utils import CursorWrapper, async_unsafe
 from salesforce.dbapi import driver as Database
 from salesforce.dbapi.driver import IntegrityError, DatabaseError, SalesforceError  # NOQA pylint:disable=unused-import
-
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse
 
 __all__ = ('DatabaseWrapper', 'DatabaseError', 'SalesforceError',)
 
@@ -63,7 +60,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     }
 
     Database = Database
-    SchemaEditorClass = DatabaseSchemaEditor
+    SchemaEditorClass = DatabaseSchemaEditor  # type: ignore  # this is normal in Django
 
     # Classes instantiated in __init__().
     client_class = DatabaseClient

--- a/salesforce/backend/base.py
+++ b/salesforce/backend/base.py
@@ -60,7 +60,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     }
 
     Database = Database
-    SchemaEditorClass = DatabaseSchemaEditor  # type: ignore  # this is normal in Django
+    SchemaEditorClass = DatabaseSchemaEditor  # type: ignore[assignment] # noqa # this is normal in Django
 
     # Classes instantiated in __init__().
     client_class = DatabaseClient

--- a/salesforce/backend/base.py
+++ b/salesforce/backend/base.py
@@ -125,6 +125,10 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         """
         return CursorWrapper(self)
 
+    def create_cursor(self, name=None):
+        row_type = {'dict': dict, 'list': list, None: None}[name]
+        return self.connection.cursor(row_type=row_type)
+
     def quote_name(self, name):
         """
         Do not quote column and table names in the SOQL dialect.

--- a/salesforce/backend/base.py
+++ b/salesforce/backend/base.py
@@ -139,3 +139,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             cur.execute("SELECT IsSandbox FROM Organization")
             self._is_sandbox = cur.fetchone()[0]
         return self._is_sandbox
+
+    def close(self):
+        if self.connection:
+            self.connection.close()

--- a/salesforce/backend/compiler.py
+++ b/salesforce/backend/compiler.py
@@ -16,7 +16,7 @@ from django.db.models.sql.where import AND
 from django.db.transaction import TransactionManagementError
 
 import salesforce.backend.models_lookups   # required for activation of lookups
-from salesforce.backend import DJANGO_21_PLUS, DJANGO_30_PLUS
+from salesforce.backend import DJANGO_21_PLUS, DJANGO_30_PLUS, DJANGO_31_PLUS
 from salesforce.dbapi.driver import DatabaseError
 
 # pylint:no-else-return,too-many-branches,too-many-locals
@@ -394,7 +394,32 @@ class SalesforceWhereNode(sql_where.WhereNode):
 
 
 class SQLInsertCompiler(sql_compiler.SQLInsertCompiler, SQLCompiler):  # type: ignore[misc] # noqa # as_sql
-    if DJANGO_30_PLUS:
+    if DJANGO_31_PLUS:
+
+        def execute_sql(self, returning_fields=None):
+            # copied from Django 3.1, with one line patch
+            assert not (
+                returning_fields and len(self.query.objs) != 1 and
+                not self.connection.features.can_return_rows_from_bulk_insert
+            )
+            self.returning_fields = returning_fields
+            with self.connection.cursor() as cursor:
+                # this line is the added patch:
+                cursor.prepare_query(self.query)
+                for sql, params in self.as_sql():
+                    cursor.execute(sql, params)
+                if not self.returning_fields:
+                    return []
+                if self.connection.features.can_return_rows_from_bulk_insert and len(self.query.objs) > 1:
+                    return self.connection.ops.fetch_returned_insert_rows(cursor)
+                if self.connection.features.can_return_columns_from_insert:
+                    assert len(self.query.objs) == 1
+                    return [self.connection.ops.fetch_returned_insert_columns(cursor, self.returning_params)]
+                return [(self.connection.ops.last_insert_id(
+                    cursor, self.query.get_meta().db_table, self.query.get_meta().pk.column
+                ),)]
+
+    elif DJANGO_30_PLUS:
 
         def execute_sql(self, returning_fields=None):
             # copied from Django 3.0, with one line patch

--- a/salesforce/backend/compiler.py
+++ b/salesforce/backend/compiler.py
@@ -382,7 +382,7 @@ class SalesforceWhereNode(sql_where.WhereNode):
     # pylint:enable=no-else-return,too-many-branches,too-many-locals,unused-argument
 
 
-class SQLInsertCompiler(sql_compiler.SQLInsertCompiler, SQLCompiler):
+class SQLInsertCompiler(sql_compiler.SQLInsertCompiler, SQLCompiler):  # type: ignore[misc] # noqa # as_sql
     if DJANGO_30_PLUS:
 
         def execute_sql(self, returning_fields=None):
@@ -418,7 +418,7 @@ class SQLInsertCompiler(sql_compiler.SQLInsertCompiler, SQLCompiler):
 
     else:
 
-        def execute_sql(self, return_id=False):
+        def execute_sql(self, return_id=False):  # type: ignore[misc] # noqa # check typing only for Django >= 3.0
             # copied from Django 1.11, with one line patch
             assert not (
                 return_id and len(self.query.objs) != 1 and
@@ -442,13 +442,13 @@ class SQLInsertCompiler(sql_compiler.SQLInsertCompiler, SQLCompiler):
                 )
 
 
-class SQLDeleteCompiler(sql_compiler.SQLDeleteCompiler, SQLCompiler):
+class SQLDeleteCompiler(sql_compiler.SQLDeleteCompiler, SQLCompiler):  # type: ignore[misc] # noqa # as_sql
     pass
 
 
-class SQLUpdateCompiler(sql_compiler.SQLUpdateCompiler, SQLCompiler):
+class SQLUpdateCompiler(sql_compiler.SQLUpdateCompiler, SQLCompiler):  # type: ignore[misc] # noqa # as_sql,execute_sql
     pass
 
 
-class SQLAggregateCompiler(sql_compiler.SQLAggregateCompiler, SQLCompiler):
+class SQLAggregateCompiler(sql_compiler.SQLAggregateCompiler, SQLCompiler):  # type: ignore[misc] # noqa # as_sql
     pass

--- a/salesforce/backend/compiler.py
+++ b/salesforce/backend/compiler.py
@@ -11,7 +11,8 @@ Generate queries using the SOQL dialect.  (like django.db.models.sql.compiler an
 import re
 from django.core.exceptions import EmptyResultSet
 from django.db import NotSupportedError
-from django.db.models.sql import compiler as sql_compiler, where as sql_where, constants, AND
+from django.db.models.sql import compiler as sql_compiler, where as sql_where, constants
+from django.db.models.sql.where import AND
 from django.db.transaction import TransactionManagementError
 
 import salesforce.backend.models_lookups   # required for activation of lookups

--- a/salesforce/backend/compiler.py
+++ b/salesforce/backend/compiler.py
@@ -414,8 +414,8 @@ class SQLInsertCompiler(sql_compiler.SQLInsertCompiler, SQLCompiler):  # type: i
                     return self.connection.ops.fetch_returned_insert_rows(cursor)
                 if self.connection.features.can_return_columns_from_insert:
                     if (
-                        len(self.returning_fields) > 1 and
-                        not self.connection.features.can_return_multiple_columns_from_insert
+                            len(self.returning_fields) > 1 and
+                            not self.connection.features.can_return_multiple_columns_from_insert
                     ):
                         raise NotSupportedError(
                             'Returning multiple columns from INSERT statements is '

--- a/salesforce/backend/indep.py
+++ b/salesforce/backend/indep.py
@@ -1,3 +1,5 @@
+# indep - optional functions and classes that should be independent on the
+#         rest of salesforce to not make dependency graphs complicated
 import uuid
 from inspect import getcallargs
 from typing import Any, Callable, Dict, Type
@@ -7,7 +9,7 @@ from django.db.models import Field
 
 
 class LazyField(object):
-    """A Field that can be later customized until binded to the final Model"""
+    """A Field that can be later customized until it is binded to the final Model"""
     # It does not need a deserializer for migrations because it is never passed
     # to migration tracking before before activation to a normal field
 

--- a/salesforce/backend/introspection.py
+++ b/salesforce/backend/introspection.py
@@ -24,9 +24,12 @@ import salesforce.fields
 
 log = logging.getLogger(__name__)
 
-# the last element 'params' is our extension for Salesforce
-field_info_fields = BaseFieldInfo._fields + ('params',)
-FieldInfo = namedtuple('FieldInfo', field_info_fields)  # pylint:disable=invalid-name
+FieldInfo = namedtuple(
+    'FieldInfo',
+    'name type_code display_size internal_size precision scale null_ok default'
+    ' params'  # the last name 'params' is our extension for Salesforce
+)  # pylint:disable=invalid-name
+assert FieldInfo._fields[:-1] == BaseFieldInfo._fields
 
 # these sObjects are not tables - ignore them
 # not queryable, not searchable, not retrieveable, only triggerable

--- a/salesforce/backend/introspection.py
+++ b/salesforce/backend/introspection.py
@@ -102,7 +102,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
     def __init__(self, conn: Any) -> None:
         BaseDatabaseIntrospection.__init__(self, conn)
         self._table_list_cache = None  # type: Optional[Dict[str, Any]]
-        self._table_description_cache = {}  # type: Dict[str, Any]
+        self._table_description_cache = {}  # type: Dict[str, Dict[str, Any]]
         self._converted_lead_status = None  # type: Optional[str]
 
     @property
@@ -205,7 +205,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                 key_columns.append((name,) + item['foreign_key'])
         return key_columns
 
-    def get_relations(self, cursor: _Cursor, table_name: str) -> Dict[str, Tuple[str, str]]:
+    def get_relations(self, cursor: _Cursor, table_name: str) -> Dict[str, Tuple[str, 'SfProtectName']]:
         """
         Returns a dictionary of {field_index: (field_index_other_table, other_table)}
         representing all relationships to the given table. Indexes are 0-based.
@@ -221,7 +221,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         for _, field in enumerate(self.table_description_cache(table_name)['fields']):
             if field['type'] == 'reference' and field['referenceTo']:
                 params = OrderedDict()
-                reference_to_name = SfProtectName(field['referenceTo'][0])  # type: str
+                reference_to_name = SfProtectName(field['referenceTo'][0])
                 relationship_order = field['relationshipOrder']
                 if relationship_order is None:
                     relationship_tmp = set()

--- a/salesforce/backend/introspection.py
+++ b/salesforce/backend/introspection.py
@@ -255,9 +255,9 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             if len(ilist) > 1 or back_name_collisions:
                 important_related_names.extend(ilist)
         last_introspection = LastIntrospection(
-                model_name=table2model(table_name),
-                important_related_names=important_related_names,
-                fields_map=fields_map,
+            model_name=table2model(table_name),
+            important_related_names=important_related_names,
+            fields_map=fields_map,
         )
         return result
 

--- a/salesforce/backend/introspection.py
+++ b/salesforce/backend/introspection.py
@@ -24,6 +24,7 @@ import salesforce.fields
 
 log = logging.getLogger(__name__)
 
+# the last element 'params' is our extension for Salesforce
 field_info_fields = BaseFieldInfo._fields + ('params',)
 FieldInfo = namedtuple('FieldInfo', field_info_fields)  # pylint:disable=invalid-name
 
@@ -167,6 +168,8 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                 # calculated formula field are without length in Salesforce 45 Spring '19,
                 # but Django requires a length, though the field is read only and never written
                 field['length'] = 1300
+            elif field['name'] == 'Field' and table_name == 'FieldPermissions':
+                field['length'] = 255
             # We prefer "length" over "byteLength" for "internal_size".
             # (because strings have usually: byteLength == 3 * length)
             result.append(FieldInfo(

--- a/salesforce/backend/manager.py
+++ b/salesforce/backend/manager.py
@@ -41,6 +41,7 @@ class SalesforceManager(manager.Manager, Generic[_T]):
         """
         alias_is_sf = _alias and router.is_sf_database(_alias)
         is_extended_model = getattr(self.model, '_salesforce_object', '') == 'extended'
+        assert self.model is not None
         if router.is_sf_database(self.db) or alias_is_sf or is_extended_model:
             q = models_sql_query.SalesforceQuery(self.model, where=compiler.SalesforceWhereNode)
             ret = query.SalesforceQuerySet(self.model, query=q, using=self.db)  # type: query.SalesforceQuerySet[_T]

--- a/salesforce/backend/manager.py
+++ b/salesforce/backend/manager.py
@@ -34,7 +34,7 @@ class SalesforceManager(_BaseManager):
         use_for_related_fields = True
         silence_use_for_related_fields_deprecation = True  # pylint:disable=invalid-name  # name from Django
 
-    def get_queryset(self, _alias: Optional[str] = None) -> _QuerySet:
+    def get_queryset(self, _alias: Optional[str] = None) -> '_QuerySet':
         """
         Returns a QuerySet which access remote SF objects.
         """
@@ -62,7 +62,9 @@ class SalesforceManager(_BaseManager):
     #                                            params=params, using=self.db)
     #     return super(SalesforceManager, self).raw(raw_query, params=params, translations=translations)
 
-    def query_all(self):
+    def query_all(self) -> '_QuerySet[_T]':  # type: ignore[override] # noqa
         if router.is_sf_database(self.db):
-            return self.get_queryset().query_all()
+            qs = self.get_queryset()
+            assert isinstance(qs, query.SalesforceQuerySet)
+            return qs.query_all()
         return self.get_queryset()

--- a/salesforce/backend/models_sql_query.py
+++ b/salesforce/backend/models_sql_query.py
@@ -87,6 +87,7 @@ class SalesforceQuery(Query, Generic[_T]):
         """
         Performs a COUNT() query using the current filter constraints.
         """
+        # customized because "Count('*')" is not possbel wit Salesforce and also not "__" in an alias
         obj = self.clone()
         obj.add_annotation(Count('pk'), alias='x_sf_count', is_summary=True)  # pylint: disable=no-member
         number = obj.get_aggregation(using, ['x_sf_count'])['x_sf_count']  # type: Optional[int] # pylint: disable=no-member # noqa

--- a/salesforce/backend/models_sql_query.py
+++ b/salesforce/backend/models_sql_query.py
@@ -41,7 +41,7 @@ class SalesforceQuery(Query):
     """
     Override aggregates.
     """
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super(SalesforceQuery, self).__init__(*args, **kwargs)
         self.is_query_all = False
         self.max_depth = 1
@@ -75,7 +75,7 @@ class SalesforceQuery(Query):
         compiler = q.get_compiler(using=using)  # pylint: disable=no-member
         return bool(compiler.execute_sql(constants.SINGLE))
 
-    def set_query_all(self):
+    def set_query_all(self) -> None:
         self.is_query_all = True
 
     def get_count(self, using):

--- a/salesforce/backend/operations.py
+++ b/salesforce/backend/operations.py
@@ -10,9 +10,9 @@ DatabaseOperations  (like salesforce.db.backends.*.operations)
 import itertools
 
 import django.db.backends.utils
-from django.utils.deconstruct import deconstructible
 from django.db.backends.base.operations import BaseDatabaseOperations
 from salesforce.backend import DJANGO_30_PLUS
+from salesforce.defaults import DefaultedOnCreate
 
 BULK_BATCH_SIZE = 200
 
@@ -111,31 +111,3 @@ class DatabaseOperations(BaseDatabaseOperations):
         The same is necessary for boolean fields, e.g. IsActive=true
         """
         False
-
-
-@deconstructible
-class DefaultedOnCreate(object):
-    """
-    The default value which denotes that the value should skipped and
-    replaced later on the SFDC server.
-
-    It should not be replaced by Django, because SF can do it better or
-    even no real ralue neither None is accepted.
-    SFDC can set the correct value only if the field is omitted as the REST API.
-    (No normal soulution exists e.g. for some builtin foreign keys with
-    SF attributes 'defaultedOnCreate: true, nillable: false')
-
-    Example: `Owner` field is assigned to the current user if the field User is omitted.
-
-        Owner = models.ForeignKey(User, on_delete=models.DO_NOTHING,
-                default=models.DefaultedOnCreate(),
-                db_column='OwnerId')
-    """
-    # pylint:disable=too-few-public-methods
-    def __init__(self, arg=None):
-        self.arg = arg
-
-    def __str__(self):
-        if self.arg is None:
-            return 'DEFAULTED_ON_CREATE'
-        return 'DefaultedOnCreate({})'.format(repr(self.arg))

--- a/salesforce/backend/operations.py
+++ b/salesforce/backend/operations.py
@@ -13,7 +13,6 @@ import warnings
 import django.db.backends.utils
 from django.db.backends.base.operations import BaseDatabaseOperations
 from salesforce.backend import DJANGO_30_PLUS
-from salesforce.defaults import DefaultedOnCreate
 from salesforce.dbapi.exceptions import SalesforceWarning
 
 BULK_BATCH_SIZE = 200
@@ -95,7 +94,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         return value
 
     def adapt_decimalfield_value(self, value, max_digits=None, decimal_places=None):
-        if isinstance(value, DefaultedOnCreate):
+        if hasattr(value, 'default'):  # DefaultedOnCreate
             return value
         return django.db.backends.utils.format_number(value, max_digits, decimal_places)
 

--- a/salesforce/backend/query.py
+++ b/salesforce/backend/query.py
@@ -8,7 +8,7 @@
 """
 Salesforce object query and queryset customizations.  (like django.db.models.query)
 """
-from typing import Generic, Iterable, List, Optional, TypeVar
+from typing import Generic, Iterable, List, Optional, TYPE_CHECKING, TypeVar
 import typing
 import warnings
 
@@ -38,7 +38,8 @@ class SalesforceQuerySet(models_query.QuerySet, Generic[_T]):
     """
     Use a custom SQL compiler to generate SOQL-compliant queries.
     """
-    query = None  # type: SalesforceQuery[_T]
+    if TYPE_CHECKING:
+        query = None  # type: SalesforceQuery[_T]
 
     def using(self, alias: Optional[str]) -> 'SalesforceQuerySet[_T]':
         if alias is None:

--- a/salesforce/backend/query.py
+++ b/salesforce/backend/query.py
@@ -15,7 +15,7 @@ from django.db.models import query
 import django
 
 from salesforce.backend.indep import get_sf_alt_pk
-from salesforce.backend import DJANGO_20_PLUS
+from salesforce.backend import DJANGO_20_PLUS, DJANGO_22_PLUS
 from salesforce.router import is_sf_database
 import salesforce
 
@@ -54,6 +54,7 @@ class SalesforceQuerySet(query.QuerySet):
     def bulk_create(self, objs, batch_size=None, ignore_conflicts=False, **kwargs):
         # pylint:disable=arguments-differ,unused-argument
         # parameter 'ignore_conflicts=False' is new in Django 2.2
+        kwargs = {'ignore_conflicts': ignore_conflicts} if DJANGO_22_PLUS else {}
         if getattr(self.model, '_salesforce_object', '') == 'extended' and not is_sf_database(self.db):
             objs = list(objs)
             for x in objs:

--- a/salesforce/backend/utils.py
+++ b/salesforce/backend/utils.py
@@ -5,7 +5,7 @@ import datetime
 import decimal
 import logging
 import warnings
-from typing import Callable, TypeVar, Union, overload
+from typing import Any, Callable, Tuple, TypeVar, Union, overload
 
 import pytz
 from django.conf import settings
@@ -249,7 +249,7 @@ class CursorWrapper(object):
     def prepare_query(self, query):
         self.query = query
 
-    def execute_django(self, soql, args=()):
+    def execute_django(self, soql: str, args: Tuple[Any, ...] = ()):
         """
         Fixed execute for queries coming from Django query compilers
         """
@@ -272,7 +272,7 @@ class CursorWrapper(object):
             raise DatabaseError("Unsupported query: type %s: %s" % (type(self.query), self.query))
         return response
 
-    def execute_select(self, soql, args):
+    def execute_select(self, soql: str, args) -> None:
         if soql != MIGRATIONS_QUERY_TO_BE_IGNORED:
             # normal query
             is_query_all = self.query and self.query.is_query_all
@@ -288,7 +288,7 @@ class CursorWrapper(object):
             self.cursor.rowcount = 0
         self.rowcount = self.cursor.rowcount
 
-    def query_more(self, nextRecordsUrl):
+    def query_more(self, nextRecordsUrl: str):
         return self.handle_api_exceptions('GET', nextRecordsUrl)
 
     def execute_insert(self, query):

--- a/salesforce/backend/utils.py
+++ b/salesforce/backend/utils.py
@@ -158,6 +158,7 @@ def extract_values_inner(row, query):
                     .format(field.model._meta.object_name, field.name),
                     SalesforceWarning
                 )
+                continue
         elif isinstance(query, subqueries.InsertQuery):
             value = getattr(row, field.attname)
             if (sf_read_only & NOT_CREATEABLE) != 0 or hasattr(value, 'default'):

--- a/salesforce/backend/utils.py
+++ b/salesforce/backend/utils.py
@@ -10,7 +10,6 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models, NotSupportedError
 from django.db.models.sql import subqueries, Query, RawQuery
-from six import text_type
 
 from salesforce.backend import DJANGO_30_PLUS
 from salesforce.backend.operations import DefaultedOnCreate
@@ -311,7 +310,7 @@ class CursorWrapper(object):
                     and not child.bilateral_transforms and child.lhs.target.model is self.query.model):
                 pks = child.rhs
                 if child.lookup_name == 'exact':
-                    assert isinstance(pks, text_type)
+                    assert isinstance(pks, str)
                     return [pks]
                 # lookup_name 'in'
                 assert not child.bilateral_transforms
@@ -401,7 +400,7 @@ class CursorWrapper(object):
         return str_dict(ret.json())
 
     def id_request(self):
-        """The Force.com Identity Service (return type dict of text_type)"""
+        """The Force.com Identity Service (return type dict of str)"""
         # https://developer.salesforce.com/page/Digging_Deeper_into_OAuth_2.0_at_Salesforce.com?language=en&language=en#The_Force.com_Identity_Service
 
         if 'id' in self.oauth:

--- a/salesforce/backend/utils.py
+++ b/salesforce/backend/utils.py
@@ -334,7 +334,9 @@ class CursorWrapper(object):
                 assert not child.bilateral_transforms
                 if isinstance(pks, (tuple, list)):
                     return pks
-                assert isinstance(pks, Query) and type(pks).__name__ == 'SalesforceQuery'
+                assert isinstance(pks, Query) and type(pks).__name__ == 'SalesforceQuery', (
+                    "Too complicated queryset.update(). Rewrite it by two querysets. "
+                    "See docs wiki/error-messages")
                 # # alternative solution:
                 # return list(salesforce.backend.query.SalesforceQuerySet(pk.model, query=pk, using=pk._db))
 

--- a/salesforce/backend/utils.py
+++ b/salesforce/backend/utils.py
@@ -13,7 +13,6 @@ from django.db import models, NotSupportedError
 from django.db.models.sql import subqueries, Query, RawQuery
 
 from salesforce.backend import DJANGO_30_PLUS
-from salesforce.backend.operations import DefaultedOnCreate
 from salesforce.dbapi.driver import (
     DatabaseError, merge_dict,
     register_conversion, arg_to_json, SALESFORCE_DATETIME_FORMAT)
@@ -158,7 +157,7 @@ def extract_values_inner(row, query):
         if isinstance(field, (models.ForeignKey, models.BooleanField, models.DecimalField)):
             if value in ('DEFAULT', 'DEFAULTED_ON_CREATE'):
                 continue
-        if isinstance(value, DefaultedOnCreate):
+        if hasattr(value, 'default'):
             continue
         d[field.column] = arg_to_json(value)
     return d

--- a/salesforce/backend/utils.py
+++ b/salesforce/backend/utils.py
@@ -322,7 +322,8 @@ class CursorWrapper(object):
             # simple cases are optimized, especially because a suboptimal
             # nested query based on the same table is not allowed by SF
             child = where.children[0]
-            if (child.lookup_name in ('exact', 'in') and child.lhs.target.column == 'Id'
+            if (hasattr(child, 'lookup_name') and child.lookup_name in ('exact', 'in')
+                    and child.lhs.target.column == 'Id'
                     and not child.bilateral_transforms and child.lhs.target.model is self.query.model):
                 pks = child.rhs
                 if child.lookup_name == 'exact':

--- a/salesforce/dbapi/__init__.py
+++ b/salesforce/dbapi/__init__.py
@@ -14,6 +14,7 @@ on Salesforce (but not on Django) has to be better for development,
 maintenance and testing.
 """
 
+from typing import Any
 import logging
 log = logging.getLogger(__name__)
 
@@ -21,6 +22,7 @@ log = logging.getLogger(__name__)
 # Dependencies of salesforce.dbapi on Django are tried to be minimalized.
 # The biggest challenges are django.conf.settings, django.db.connections and django.test.
 try:
+    settings = None  # type: Any
     from django.conf import settings
     from django.db import connections
 except ImportError:

--- a/salesforce/dbapi/__init__.py
+++ b/salesforce/dbapi/__init__.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 try:
     settings = None  # type: Any
     from django.conf import settings
-    from django.db import connections
+    from django.db import connections as connections
 except ImportError:
     # mock for some tests without a real Django
     import importlib
@@ -39,7 +39,7 @@ except ImportError:
     connections = local()
 
 
-def get_max_retries():
+def get_max_retries() -> int:
     """Get the maximal number of requests retries
 
     The maximal number of retries for timeouts in requests to Force.com API.
@@ -48,4 +48,4 @@ def get_max_retries():
     0: no retry
     1: one retry
     """
-    return getattr(settings, 'REQUESTS_MAX_RETRIES', 1)
+    return getattr(settings, 'REQUESTS_MAX_RETRIES', 1)  # type: ignore[no-any-return] # noqa

--- a/salesforce/dbapi/driver.py
+++ b/salesforce/dbapi/driver.py
@@ -402,8 +402,13 @@ class RawConnection(object):
 
         width_type = max(len(type_) for i, errs, type_, id_ in x_err)
         width_type = max(width_type, len('sobject'))
-        messages = ['', 'index {} sobject{:{width}s}error_info'.format(
-            ('ID' + 16 * ' ' if x_err[0][3] else ''), '', width=(width_type + 2 - len('sobject')))]
+        messages = [
+            '(see details below)',
+            '',
+            'Error Summary: errors={}, rollback/cancel={}, success={}'.format(len(x_err), len(x_roll), len(x_ok)),
+            'index {} sobject{:{width}s}error_info'.format(
+                ('ID' + 16 * ' ' if x_err[0][3] else ''), '', width=(width_type + 2 - len('sobject')))
+        ]
         for i, errs, type_, id_ in x_err:
             field_info = 'FIELDS: {}'.format(errs[0]['fields']) if errs[0].get('fields') else ''
             msg = '{:5d} {} {:{width_type}s}  {}: {} {}'.format(

--- a/salesforce/dbapi/driver.py
+++ b/salesforce/dbapi/driver.py
@@ -619,7 +619,7 @@ class Cursor(object):
         self.description = [(alias, None, None, None, name) for alias, name in
                             zip(self.qquery.aliases, self.qquery.fields)]
 
-        url_part = '?'.join((service, urlencode(dict(q=processed_sql))))
+        url_part = '/?'.join((service, urlencode(dict(q=processed_sql))))
         self.query_more(url_part)
         self._chunk_offset = 0
         self.rownumber = 0
@@ -636,7 +636,7 @@ class Cursor(object):
 
         self.qquery = QQuery(soql)
         self.description = [('detail', None, None, None, 'detail')]
-        url_part = '?'.join((service, urlencode(dict(explain=processed_sql))))
+        url_part = '/?'.join((service, urlencode(dict(explain=processed_sql))))
         ret = self.handle_api_exceptions('GET', url_part)
         self._iter = iter([[x] for x in pprint.pformat(ret.json(), indent=1, width=100).split('\n')])
 
@@ -845,7 +845,7 @@ class TimeStatistics(object):
 
     @staticmethod
     def domain(url):
-        match = re.match(r'^(?:https|mock)://([^/]+)/?', url)
+        match = re.match(r'^(?:https|mock)://([^/]*)/?', url)
         return match.groups()[0]
 
 

--- a/salesforce/dbapi/driver.py
+++ b/salesforce/dbapi/driver.py
@@ -17,7 +17,6 @@ import socket
 import sys
 import threading
 import time
-import types
 import warnings
 import weakref
 from collections import namedtuple
@@ -35,7 +34,7 @@ from salesforce.dbapi import settings  # i.e. django.conf.settings
 from salesforce.dbapi.exceptions import (  # NOQA pylint: disable=unused-import
     Error, InterfaceError, DatabaseError, DataError, OperationalError, IntegrityError,
     InternalError, ProgrammingError, NotSupportedError, SalesforceError, SalesforceWarning,
-    warn_sf, PY3, text_type)
+    warn_sf)
 from salesforce.dbapi.subselect import QQuery
 
 try:
@@ -594,8 +593,6 @@ class Cursor(object):
     def __next__(self):
         return next(self._iter)
 
-    next = __next__  # Python 2
-
     # -- private methods
 
     def __iter__(self):
@@ -681,7 +678,7 @@ class Cursor(object):
 #                              The first two items are mandatory. (name, type)
 CursorDescription = namedtuple('CursorDescription', 'name type_code '
                                'display_size internal_size precision scale null_ok')
-CursorDescription.__new__.func_defaults = 7 * (None,)
+CursorDescription.__new__.__defaults__ = 7 * (None,)
 
 
 def standard_errorhandler(connection, cursor, errorclass, errorvalue):
@@ -815,13 +812,6 @@ register_conversion(datetime.time,   json_conv=lambda d: datetime.time.strftime(
 register_conversion(decimal.Decimal, json_conv=float, subclass=True)
 # the type models.Model is registered from backend, because it is a Django type
 # pylint:enable=bad-whitespace
-
-if not PY3:
-    # pylint:disable=no-member
-    register_conversion(types.LongType, json_conv=str)
-    register_conversion(types.UnicodeType,
-                        json_conv=lambda s: s.encode('utf8'),
-                        sql_conv=lambda s: quoted_string_literal(s.encode('utf8')))
 
 
 def merge_dict(dict_1, *other, **kw):

--- a/salesforce/dbapi/driver.py
+++ b/salesforce/dbapi/driver.py
@@ -482,7 +482,7 @@ def connect(**params) -> Connection:
 def get_connection(alias: str, **params) -> Connection:
     if not hasattr(thread_connections, alias):
         setattr(thread_connections, alias, connect(alias=alias, **params))
-    return getattr(thread_connections, alias)
+    return cast(Connection, getattr(thread_connections, alias))
 
 
 class Cursor(Generic[_TRow]):
@@ -837,7 +837,7 @@ subclass_conversions = []  # type: List[type]
 register_conversion(int,             json_conv=str)
 register_conversion(float,           json_conv=lambda o: '%.15g' % o)
 register_conversion(type(None),      json_conv=lambda s: None,          sql_conv=lambda s: 'NULL')
-register_conversion(str,             json_conv=lambda o: o,             sql_conv=quoted_string_literal)  # default
+register_conversion(str,             json_conv=lambda o: cast(str, o),  sql_conv=quoted_string_literal)  # default
 register_conversion(bool,            json_conv=lambda s: str(s).lower())
 register_conversion(datetime.date,   json_conv=lambda d: datetime.date.strftime(d, "%Y-%m-%d"))
 register_conversion(datetime.datetime, json_conv=date_literal)
@@ -876,7 +876,7 @@ class TimeStatistics:
     def domain(url) -> str:
         match = re.match(r'^(?:https|mock)://([^/]*)/?', url)
         assert match
-        return match.groups()[0]
+        return cast(str, match.groups()[0])
 
 
 time_statistics = TimeStatistics(300)

--- a/salesforce/dbapi/exceptions.py
+++ b/salesforce/dbapi/exceptions.py
@@ -1,10 +1,7 @@
 # All error types described in DB API 2 are implemented the same way as in
 # Django (1.11 to 3.0)., otherwise some exceptions are not correctly reported in it.
 import json
-import sys
 import warnings
-PY3 = sys.version_info[0] == 3
-text_type = str if PY3 else type(u'')
 # pylint:disable=too-few-public-methods
 
 
@@ -15,8 +12,7 @@ class SalesforceWarning(Warning):
         super(SalesforceWarning, self).__init__(message)
 
 
-class Error(Exception if PY3 else StandardError):  # NOQA pylint:disable=undefined-variable
-    #                                              # StandardError is undefined in PY3
+class Error(Exception):
     """
     Database error that can get detailed error information from a SF REST API response.
 
@@ -98,7 +94,7 @@ def prepare_exception(obj, messages=None, response=None, verbs=None):
     known_options = ['method+url']
     if messages is None:
         messages = []
-    if isinstance(messages, (text_type, str)):
+    if isinstance(messages, str):
         messages = [messages]
     assert isinstance(messages, list)
     assert not verbs.difference(known_options)
@@ -129,8 +125,6 @@ def prepare_exception(obj, messages=None, response=None, verbs=None):
             data_info = ' (without json request data)'
         messages.append('in {} "{}"{}'.format(method, url, data_info))
     separ = '\n    '
-    if not PY3:
-        messages = [x if isinstance(x, str) else x.encode('utf-8') for x in messages]
     messages = [x.replace('\n', separ) for x in messages]
     message = separ.join(messages)
     if obj:

--- a/salesforce/dbapi/exceptions.py
+++ b/salesforce/dbapi/exceptions.py
@@ -7,6 +7,8 @@ import warnings
 # pylint:disable=too-few-public-methods
 
 
+# === Forward defs  (they are first due to dependency)
+
 class FakeReq:
     """A Fake Request is used for compatible error reporting in "composite" subrequests."""
     # pylint:disable=too-few-public-methods,too-many-arguments
@@ -43,6 +45,8 @@ class FakeResp:  # pylint:disable=too-few-public-methods,too-many-instance-attri
 
 GenResponse = requests.Response  # (requests.Response, 'FakeResp')
 
+
+# === Exception defs
 
 class SalesforceWarning(Warning):
     def __init__(self,

--- a/salesforce/dbapi/subselect.py
+++ b/salesforce/dbapi/subselect.py
@@ -15,11 +15,13 @@ require a combined parser for parentheses and commas.
 
 Unsupported GROUP BY ROLLUP and GROUP BY CUBE (their syntax for reports).
 """
+from typing import Any, Dict, List, Optional, TypeVar, Union
 import datetime
 import re
 import pytz
 from salesforce.dbapi.exceptions import ProgrammingError
 
+_TRow = TypeVar('_TRow', list, dict)
 # reserved wods can not be used as alias names
 RESERVED_WORDS = set((
     'AND, ASC, DESC, EXCLUDES, FIRST, FROM, GROUP, HAVING, '
@@ -53,12 +55,12 @@ class QQuery(object):
 
     # pylint:disable=too-few-public-methods,too-many-instance-attributes
 
-    def __init__(self, soql=None):
+    def __init__(self, soql: Optional[str] = None) -> None:
         self.soql = None
-        self.fields = []
+        self.fields = []                  # type: List[Union[str, QQuery]]
         # dictionary of chil to parent relationships - lowercase keys
-        self.subroots = {}
-        self.aliases = []
+        self.subroots = {}                # type: Dict[str, Any]  # recursive is Any
+        self.aliases = []                 # type: List[str]
         self.root_table = None
         # is_aggregation: only to know if aliases are relevant for output
         self.is_aggregation = False

--- a/salesforce/dbapi/subselect.py
+++ b/salesforce/dbapi/subselect.py
@@ -176,7 +176,6 @@ class QQuery(object):
 
 SALESFORCE_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%f+0000'
 SF_DATETIME_PATTERN = re.compile(r'[1-3]\d{3}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-6]\d.\d{3}\+0000$')
-TextType = type(u'')
 
 
 def fix_data_type(data, tzinfo=None):
@@ -184,7 +183,7 @@ def fix_data_type(data, tzinfo=None):
     # from some reliable field mapping, not to guess by regexp like here.
     # Only a DateTime field has so specific regexp that the guess is
     # acceptable.
-    if isinstance(data, TextType) and SF_DATETIME_PATTERN.match(data):
+    if isinstance(data, str) and SF_DATETIME_PATTERN.match(data):
         datim = datetime.datetime.strptime(data, SALESFORCE_DATETIME_FORMAT)
         datim = datim.replace(tzinfo=tzinfo or pytz.utc)
         return datim

--- a/salesforce/dbapi/test_helpers.py
+++ b/salesforce/dbapi/test_helpers.py
@@ -2,12 +2,9 @@ import sys
 import traceback
 from contextlib import contextmanager
 from unittest import expectedFailure
+from unittest import mock  # pylint:disable=unused-import  # NOQA
 
 from salesforce.dbapi import connections, driver
-try:
-    from unittest import mock  # pylint:disable=unused-import
-except ImportError:
-    import mock  # NOQA
 
 
 def expectedFailureIf(condition):

--- a/salesforce/defaults.py
+++ b/salesforce/defaults.py
@@ -17,15 +17,15 @@ class BaseDefault:
 
     default = None  # type: Any
 
-    def __init__(self, *args):
+    def __init__(self, *args: Any) -> None:
         self.args = args
 
     def __str__(self) -> str:
         return StrDefault(super().__str__())
 
-    def deconstruct(self) -> Tuple[str, List[Any], Dict]:
+    def deconstruct(self) -> Tuple[str, Tuple[Any, ...], Dict[str, Any]]:
         if self == self.default:
-            return ('salesforce.fields.DefaultedOnCreate', [], {})
+            return ('salesforce.fields.DefaultedOnCreate', (), {})
         else:
             return ('salesforce.fields.DefaultedOnCreate', self.args, {})
 
@@ -64,10 +64,10 @@ class StrDefault(BaseDefault, str):
 class DateDefault(BaseDefault, datetime.date):
     default = datetime.date(1700, 1, 1)
 
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *args: Any, **kwargs: Any) -> 'DateDefault':
         if len(args) == 1 and not kwargs:
             args = args[0].timetuple()[:3]
-        return super().__new__(cls, *args, **kwargs)
+        return super().__new__(cls, *args, **kwargs)  # type: ignore[call-arg,no-any-return] # noqa
 
     def isoformat(self) -> str:
         return StrDefault(super().isoformat())
@@ -76,12 +76,12 @@ class DateDefault(BaseDefault, datetime.date):
 class DateTimeDefault(BaseDefault, datetime.datetime):
     default = datetime.datetime(1700, 1, 1, 12, 0, 0, tzinfo=utc)
 
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls: Type['DateTimeDefault'], *args: Any, **kwargs: Any) -> 'DateTimeDefault':
         if len(args) == 1 and not kwargs:
             arg = args[0]
             args = arg.timetuple()[:6] + (arg.microsecond,)
             kwargs = {'tzinfo': arg.tzinfo}
-        return super().__new__(cls, *args, **kwargs)
+        return super().__new__(cls, *args, **kwargs)  # type: ignore[call-arg,no-any-return] # noqa
 
     def isoformat(self, sep: str = 'T', timecspec: str = 'auto') -> str:
         return StrDefault(super().isoformat())
@@ -90,12 +90,12 @@ class DateTimeDefault(BaseDefault, datetime.datetime):
 class TimeDefault(BaseDefault, datetime.time):
     default = datetime.time(0, 0, 0)
 
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *args: Any, **kwargs: Any) -> 'TimeDefault':
         if len(args) == 1 and not kwargs:
             arg = args[0]
             args = (arg.hour, arg.minute, arg.second, arg.microsecond)
             kwargs = {'tzinfo': arg.tzinfo}
-        return super().__new__(cls, *args, **kwargs)
+        return super().__new__(cls, *args, **kwargs)  # type: ignore[call-arg,no-any-return] # noqa
 
     def isoformat(self, timecspec: str = 'auto') -> str:
         return StrDefault(super().isoformat())
@@ -155,7 +155,7 @@ class DefaultedOnCreate:
         'AutoField': StrDefault,
         'BigAutoField': StrDefault,
         'SmallAutoField': StrDefault,
-    }  # type: Dict[str, Type]
+    }  # type: Dict[str, Type[BaseDefault]]
 
     value_type_map = {type(klass.default): klass for klass in field_type_map.values()}
 
@@ -175,7 +175,7 @@ class DefaultedOnCreate:
             # only one instance without parameters make sense, that is in DEFAULTED_ON_CREATE
             return super(DefaultedOnCreate, cls).__new__(cls)
 
-    def deconstruct(self) -> Tuple[str, List[Any], Dict]:
+    def deconstruct(self) -> Tuple[str, List[Any], Dict[str, Any]]:
         return ('salesforce.fields.DefaultedOnCreate', [], {})
 
 

--- a/salesforce/defaults.py
+++ b/salesforce/defaults.py
@@ -1,0 +1,182 @@
+import datetime
+import decimal
+from pytz import utc
+from typing import Any, Dict, List, Optional, Tuple, Type
+
+# from django.utils.deconstruct import deconstructible
+
+
+# --- DefaultedOnCreate ---
+
+# A multiple inheritance is problematic with the current mypy 0.770 and django-stubs v1.5.0
+# probably related to  https://github.com/python/mypy/issues/3603
+# Therefore many short methods are currently repeated instead of use Mixins.
+
+
+class BaseDefault:
+
+    default = None  # type: Any
+
+    def __init__(self, *args):
+        self.args = args
+
+    def __str__(self) -> str:
+        return StrDefault(super().__str__())
+
+    def deconstruct(self) -> Tuple[str, List[Any], Dict]:
+        if self == self.default:
+            return ('salesforce.fields.DefaultedOnCreate', [], {})
+        else:
+            return ('salesforce.fields.DefaultedOnCreate', self.args, {})
+
+
+class BoolDefault(BaseDefault, int):
+    default = False
+    # the type "int" is compatible with "bool" and the type "int" can be subclassed
+    # e.g. assert 1 in {True}
+
+    def __str__(self) -> str:
+        return StrDefault(str(bool(self)))
+
+    def __repr__(self) -> str:
+        return 'salesforce.fields.DefaultedOnCreate({})'.format(bool(self))
+
+
+class IntDefault(BaseDefault, int):
+    default = 0
+
+
+class FloatDefault(BaseDefault, float):
+    default = 0.
+
+
+class DecimalDefault(BaseDefault, decimal.Decimal):
+    default = decimal.Decimal('0')
+
+
+class StrDefault(BaseDefault, str):
+    default = ''  # 'DEFAULTED_ON_CREATE'
+
+    def __str__(self) -> str:
+        return self
+
+
+class DateDefault(BaseDefault, datetime.date):
+    default = datetime.date(1700, 1, 1)
+
+    def __new__(cls, *args, **kwargs):
+        if len(args) == 1 and not kwargs:
+            args = args[0].timetuple()[:3]
+        return super().__new__(cls, *args, **kwargs)
+
+    def isoformat(self) -> str:
+        return StrDefault(super().isoformat())
+
+
+class DateTimeDefault(BaseDefault, datetime.datetime):
+    default = datetime.datetime(1700, 1, 1, 12, 0, 0, tzinfo=utc)
+
+    def __new__(cls, *args, **kwargs):
+        if len(args) == 1 and not kwargs:
+            arg = args[0]
+            args = arg.timetuple()[:6] + (arg.microsecond,)
+            kwargs = {'tzinfo': arg.tzinfo}
+        return super().__new__(cls, *args, **kwargs)
+
+    def isoformat(self, sep: str = 'T', timecspec: str = 'auto') -> str:
+        return StrDefault(super().isoformat())
+
+
+class TimeDefault(BaseDefault, datetime.time):
+    default = datetime.time(0, 0, 0)
+
+    def __new__(cls, *args, **kwargs):
+        if len(args) == 1 and not kwargs:
+            arg = args[0]
+            args = (arg.hour, arg.minute, arg.second, arg.microsecond)
+            kwargs = {'tzinfo': arg.tzinfo}
+        return super().__new__(cls, *args, **kwargs)
+
+    def isoformat(self, timecspec: str = 'auto') -> str:
+        return StrDefault(super().isoformat())
+
+
+class CallableDefault(BaseDefault):
+    default = None
+
+    def __call__(self) -> Any:
+        assert len(self.args) == 1
+        out = self.args[0]()
+        return DefaultedOnCreate.value_type_map[type(out)](out)
+
+
+class DefaultedOnCreate:
+    """
+    The default value which denotes that the value should be skipped and
+    replaced on the SFDC server later.
+
+    It should not be replaced by Django, because SF can do it better or
+    even no real value is accepted, neither None.
+    SFDC can set the correct value only if the field is omitted in the REST API.
+    (No normal soulution exists e.g. for some builtin foreign keys with
+    SF attributes 'defaultedOnCreate: true, nillable: false')
+
+    Example: `Owner` field is assigned to the current user if the field User is omitted.
+
+        Owner = models.ForeignKey(User, on_delete=models.DO_NOTHING,
+                default=models.DefaultedOnCreate(),
+                db_column='OwnerId')
+    """
+    field_type_map = {
+        'BooleanField': BoolDefault,
+        'CharField': StrDefault,
+        'DateField': DateDefault,
+        'DateTimeField': DateTimeDefault,
+        'DecimalField': DecimalDefault,
+        'DurationField': TimeDefault,
+        'FilePathField': StrDefault,
+        'FloatField': FloatDefault,
+        'IntegerField': IntDefault,
+        'BigIntegerField': IntDefault,
+        'IPAddressField': StrDefault,
+        'GenericIPAddressField': StrDefault,
+        'NullBooleanField': BoolDefault,
+        'PositiveIntegerField': IntDefault,
+        'PositiveSmallIntegerField': IntDefault,
+        'SlugField': StrDefault,
+        'SmallIntegerField': IntDefault,
+        'TextField': StrDefault,
+        'TimeField': TimeDefault,
+
+        'ForeignKey': StrDefault,
+
+        'BinaryField': StrDefault,
+        'UUIDField': StrDefault,
+        'AutoField': StrDefault,
+        'BigAutoField': StrDefault,
+        'SmallAutoField': StrDefault,
+    }  # type: Dict[str, Type]
+
+    value_type_map = {type(klass.default): klass for klass in field_type_map.values()}
+
+    def __new__(cls, value: Any = None, internal_type: Optional[str] = None) -> Any:
+        if internal_type:
+            klass = cls.field_type_map[internal_type]
+            return klass(klass.default)
+        elif value is not None:
+            if callable(value):
+                return CallableDefault(value)
+            klass2 = cls.value_type_map.get(type(value))
+            if klass2:
+                return klass2(value)
+            else:
+                raise ValueError("The type of object '{}' not found for DefaultedOnCreate".format(value))
+        else:
+            # only one instance without parameters make sense, that is in DEFAULTED_ON_CREATE
+            return super(DefaultedOnCreate, cls).__new__(cls)
+
+    def deconstruct(self) -> Tuple[str, List[Any], Dict]:
+        return ('salesforce.fields.DefaultedOnCreate', [], {})
+
+
+DEFAULTED_ON_CREATE = DefaultedOnCreate()

--- a/salesforce/fields.py
+++ b/salesforce/fields.py
@@ -9,6 +9,7 @@
 Customized fields for Salesforce, especially the primary key. (like django.db.models.fields)
 """
 
+from typing import Tuple
 import typing
 import warnings
 from decimal import Decimal
@@ -111,7 +112,7 @@ class SfField(models.Field):
             kwargs['default'] = DefaultedOnCreate(internal_type=self.get_internal_type())
         super(SfField, self).__init__(*args, **kwargs)
 
-    def get_attname_column(self):
+    def get_attname_column(self) -> Tuple[str, str]:
         """
         Get the database column name automatically in most cases.
         """
@@ -281,14 +282,14 @@ class SfForeignObjectMixin(SfField, _MixinTypingBase):
                 % (on_delete, to))
         super().__init__(to, on_delete, *args, **kwargs)
 
-    def get_attname(self):
+    def get_attname(self) -> str:
         if self.name.islower():  # pylint:disable=no-else-return
             # the same as django.db.models.fields.related.ForeignKey.get_attname
             return '%s_id' % self.name
         else:
             return '%sId' % self.name
 
-    def get_attname_column(self):
+    def get_attname_column(self) -> Tuple[str, str]:
         attname, column = super().get_attname_column()
         if self.db_column is None and not self.sf_custom:
             column += 'Id'

--- a/salesforce/fields.py
+++ b/salesforce/fields.py
@@ -14,7 +14,7 @@ import warnings
 from decimal import Decimal
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.db.models import fields
 from django.db.models import PROTECT, DO_NOTHING  # NOQA pylint:disable=unused-import
 from django.db import models

--- a/salesforce/fields.py
+++ b/salesforce/fields.py
@@ -47,6 +47,12 @@ class SalesforceAutoField(fields.AutoField):
         'invalid': _('This value must be a valid Salesforce ID.'),
     }
 
+    def __init__(self, *args, **kwargs):
+        # The parameter 'sf_read_only' is not used normally, maybe only if someone
+        # added SalesforceAutoFields to the Model manually
+        kwargs.pop('sf_read_only', None)
+        super().__init__(*args, **kwargs)
+
     def to_python(self, value):
         if isinstance(value, str) or value is None:
             return value

--- a/salesforce/fields.py
+++ b/salesforce/fields.py
@@ -17,8 +17,6 @@ from django.utils.translation import ugettext_lazy as _
 from django.db.models import fields
 from django.db.models import PROTECT, DO_NOTHING  # NOQA pylint:disable=unused-import
 from django.db import models
-from django.utils.encoding import smart_text
-from six import string_types
 
 from salesforce.backend.operations import DefaultedOnCreate
 
@@ -51,9 +49,9 @@ class SalesforceAutoField(fields.AutoField):
     }
 
     def to_python(self, value):
-        if isinstance(value, string_types) or value is None:
+        if isinstance(value, str) or value is None:
             return value
-        return smart_text(value)
+        return str(value)
 
     def get_prep_value(self, value):
         return self.to_python(value)

--- a/salesforce/fields.py
+++ b/salesforce/fields.py
@@ -21,9 +21,8 @@ from django.db import models
 
 from salesforce.defaults import DEFAULTED_ON_CREATE, DefaultedOnCreate
 
-# None of field types defined in this module need a "deconstruct" method,
-# in Django 1.7+, because their parameters only describe fixed nature of SF
-# standard objects that can not be modified no ways by no API or spell.
+# None of field types defined here don't need a "deconstruct" method.
+# Their parameters only describe the different, but stable nature of SF standard objects.
 
 FULL_WRITABLE = 0
 NOT_UPDATEABLE = 1
@@ -77,7 +76,7 @@ class SalesforceAutoField(fields.AutoField):
                     )
                 )
             # A model is created  that inherits fields from more abstract classes
-            # with the same default SalesforceAutoFieldy. Therefore the second should be
+            # with the same default SalesforceAutoField. Therefore the second should be
             # ignored.
             return
         super(SalesforceAutoField, self).contribute_to_class(cls, name, **kwargs)
@@ -133,7 +132,7 @@ class SfField(models.Field):
         return attname, column
 
     def contribute_to_class(self, cls, name, private_only=False, **kwargs):
-        # Different arguments are in Django 1.11 vs. 2.0, therefore we use universal **kwargs
+        # More arguments are in Django 1.11 than in Django 2.0, therefore we use the universal **kwargs
         # pylint:disable=arguments-differ
         super(SfField, self).contribute_to_class(cls, name, private_only=private_only, **kwargs)
         if self.sf_custom is None and hasattr(cls._meta, 'sf_custom'):
@@ -205,7 +204,7 @@ class DecimalField(SfField, models.DecimalField):
                 ret = Decimal(int(ret))
         return ret
 
-    # parameter "context" is for Django <= 1.11, removed in Django 3.0 (the same is in more classes here)
+    # parameter "context" is for Django <= 1.11 (the same is in more classes here)
     def from_db_value(self, value, expression, connection, context=None):
         # pylint:disable=unused-argument
         # TODO refactor and move to the driver like in other backends
@@ -223,7 +222,11 @@ class FloatField(SfField, models.FloatField):
 
 
 class BooleanField(SfField, models.BooleanField):
-    """BooleanField with sf_read_only attribute for Salesforce."""
+    """BooleanField with sf_read_only attribute for Salesforce.
+
+    No NullBooleanField exist for Salesforce and every BooleanField has
+    a default value. Implicit default is False if not specified.
+    """
     def __init__(self, default=False, **kwargs):
         super(BooleanField, self).__init__(default=default, **kwargs)
 

--- a/salesforce/fields.py
+++ b/salesforce/fields.py
@@ -9,6 +9,7 @@
 Customized fields for Salesforce, especially the primary key. (like django.db.models.fields)
 """
 
+import typing
 import warnings
 from decimal import Decimal
 from django.conf import settings
@@ -251,8 +252,15 @@ class TimeField(SfField, models.TimeField):
         return self.to_python(value)
 
 
-class ForeignKey(SfField, models.ForeignKey):
-    """ForeignKey with sf_read_only attribute and acceptable by Salesforce."""
+if typing.TYPE_CHECKING:
+    # static typing of a mixin requires an additional base, that is not necessary
+    # at runtime
+    _MixinTypingBase = models.ForeignObject
+else:
+    _MixinTypingBase = object
+
+
+class SfForeignObjectMixin(SfField, _MixinTypingBase):
     def __init__(self, to, on_delete, *args, **kwargs):
         # Checks parameters before call to ancestor.
         if on_delete.__name__ not in ('PROTECT', 'DO_NOTHING'):
@@ -266,7 +274,7 @@ class ForeignKey(SfField, models.ForeignKey):
                 "Only foreign keys with on_delete = PROTECT or "
                 "DO_NOTHING are currently supported, not %s related to %s"
                 % (on_delete, to))
-        super(ForeignKey, self).__init__(to, on_delete, *args, **kwargs)
+        super().__init__(to, on_delete, *args, **kwargs)
 
     def get_attname(self):
         if self.name.islower():  # pylint:disable=no-else-return
@@ -276,15 +284,18 @@ class ForeignKey(SfField, models.ForeignKey):
             return '%sId' % self.name
 
     def get_attname_column(self):
-        attname, column = super(ForeignKey, self).get_attname_column()
+        attname, column = super().get_attname_column()
         if self.db_column is None and not self.sf_custom:
             column += 'Id'
         return attname, column
 
 
-class OneToOneField(ForeignKey, models.OneToOneField):
-    """OneToOneField with sf_read_only attribute and acceptable by Salesforce."""
-    pass
+class ForeignKey(SfForeignObjectMixin, models.ForeignKey):
+    """ForeignKey with sf_read_only attribute that is acceptable by Salesforce."""
+
+
+class OneToOneField(SfForeignObjectMixin, models.OneToOneField):
+    """OneToOneField with sf_read_only attribute that is acceptable by Salesforce."""
 
 
 AutoField = SalesforceAutoField

--- a/salesforce/models.py
+++ b/salesforce/models.py
@@ -27,12 +27,13 @@ from six import with_metaclass
 
 from salesforce.backend import manager, DJANGO_20_PLUS
 from salesforce.fields import SalesforceAutoField, SF_PK, SfField, ForeignKey
-from salesforce.fields import DEFAULTED_ON_CREATE, NOT_UPDATEABLE, NOT_CREATEABLE, READ_ONLY
+from salesforce.fields import DefaultedOnCreate, DEFAULTED_ON_CREATE
+from salesforce.fields import NOT_UPDATEABLE, NOT_CREATEABLE, READ_ONLY
 from salesforce.fields import *  # NOQA pylint:disable=unused-wildcard-import,wildcard-import
 from salesforce.backend.indep import LazyField
 
 __all__ = ('SalesforceModel', 'Model', 'DEFAULTED_ON_CREATE', 'PROTECT', 'DO_NOTHING', 'SF_PK', 'SfField',
-           'NOT_UPDATEABLE', 'NOT_CREATEABLE', 'READ_ONLY')
+           'NOT_UPDATEABLE', 'NOT_CREATEABLE', 'READ_ONLY', 'DefaultedOnCreate')
 
 log = logging.getLogger(__name__)
 

--- a/salesforce/models.py
+++ b/salesforce/models.py
@@ -66,34 +66,36 @@ class SalesforceModelBase(ModelBase):
             super(SalesforceModelBase, cls).add_to_class(name, value)  # pylint: disable=no-value-for-parameter
             setattr(cls._meta, 'sf_custom', sf_custom)
         else:
-            if type(value) is models.manager.Manager:  # pylint:disable=unidiomatic-typecheck
-                # this is for better migrations because: obj._constructor_args = (args, kwargs)
-                _constructor_args = value._constructor_args
-                value = manager.SalesforceManager()
-                value._constructor_args = _constructor_args
+            if True:
+                if type(value) is models.manager.Manager:  # pylint:disable=unidiomatic-typecheck
+                    # this is for better migrations because: obj._constructor_args = (args, kwargs)
+                    _constructor_args = value._constructor_args
+                    value = manager.SalesforceManager()
+                    value._constructor_args = _constructor_args
 
-            super(SalesforceModelBase, cls).add_to_class(name, value)  # pylint: disable=no-value-for-parameter
+                super(SalesforceModelBase, cls).add_to_class(name, value)  # pylint: disable=no-value-for-parameter
 
 
-# pylint:disable=too-few-public-methods
-class SalesforceModel(models.Model, metaclass=SalesforceModelBase):
-    """
-    Abstract model class for Salesforce objects.
-    """
-    # pylint:disable=invalid-name
-    _salesforce_object = 'standard'
-    objects = manager.SalesforceManager()
+if True:
+    # pylint:disable=too-few-public-methods
+    class SalesforceModel(models.Model, metaclass=SalesforceModelBase):
+        """
+        Abstract model class for Salesforce objects.
+        """
+        # pylint:disable=invalid-name
+        _salesforce_object = 'standard'
+        objects = manager.SalesforceManager()
 
-    class Meta:
-        abstract = True
-        base_manager_name = 'objects'
-        if not DJANGO_20_PLUS:
-            manager_inheritance_from_future = True
+        class Meta:
+            abstract = True
+            base_manager_name = 'objects'
+            if not DJANGO_20_PLUS:
+                manager_inheritance_from_future = True
 
-    # Name of primary key 'Id' can be easily changed to 'id'
-    # by "settings.SF_PK='id'".
-    id = SalesforceAutoField(primary_key=True, name=SF_PK, db_column='Id',
-                             verbose_name='ID', auto_created=True)
+        # Name of primary key 'Id' can be easily changed to 'id'
+        # by "settings.SF_PK='id'".
+        id = SalesforceAutoField(primary_key=True, name=SF_PK, db_column='Id',
+                                 verbose_name='ID', auto_created=True)
 
 
 class ModelTemplate(object):

--- a/salesforce/models.py
+++ b/salesforce/models.py
@@ -13,7 +13,6 @@ column names are all in CamelCase. No attempt is made to work around this
 issue, but normal use of `db_column` and `db_table` parameters should work.
 """
 
-from __future__ import unicode_literals
 from inspect import isclass
 import logging
 import warnings
@@ -23,7 +22,6 @@ from django.db.models.base import ModelBase
 # Only these two `on_delete` options are currently supported
 from django.db.models import PROTECT, DO_NOTHING  # NOQA pylint:disable=unused-wildcard-import,wildcard-import
 # from django.db.models import CASCADE, PROTECT, SET_NULL, SET, DO_NOTHING
-from six import with_metaclass
 
 from salesforce.backend import manager, DJANGO_20_PLUS
 from salesforce.fields import SalesforceAutoField, SF_PK, SfField, ForeignKey
@@ -78,7 +76,7 @@ class SalesforceModelBase(ModelBase):
 
 
 # pylint:disable=too-few-public-methods
-class SalesforceModel(with_metaclass(SalesforceModelBase, models.Model)):
+class SalesforceModel(models.Model, metaclass=SalesforceModelBase):
     """
     Abstract model class for Salesforce objects.
     """

--- a/salesforce/models_extend.py
+++ b/salesforce/models_extend.py
@@ -48,41 +48,42 @@ class SfCharAutoField(SalesforceAutoField):
             return models.CharField(max_length=32).db_type(connection=connection)
 
 
-# pylint:disable=too-few-public-methods,function-redefined
-class SalesforceModel(models.Model, metaclass=SalesforceModelBase):  # type: ignore[no-redef] # noqa # redefined
-    """
-    Abstract model class for Salesforce objects that can be saved to other db.
+if True:
+    # pylint:disable=too-few-public-methods,function-redefined
+    class SalesforceModel(models.Model, metaclass=SalesforceModelBase):  # type: ignore[no-redef] # noqa # redefined
+        """
+        Abstract model class for Salesforce objects that can be saved to other db.
 
-    (It is not a subclass of salesforce.models.SalesforceModel. That is not
-    a big problem if we don't check inheritance but only the '_salesforce_object'
-    attribute or if we use only this or only the original implementation.)
-    """
-    # pylint:disable=invalid-name
-    _salesforce_object = 'extended'
-    objects = manager.SalesforceManager()
+        (It is not a subclass of salesforce.models.SalesforceModel. That is not
+        a big problem if we don't check inheritance but only the '_salesforce_object'
+        attribute or if we use only this or only the original implementation.)
+        """
+        # pylint:disable=invalid-name
+        _salesforce_object = 'extended'
+        objects = manager.SalesforceManager()
 
-    class Meta:
-        # pylint:disable=duplicate-code
-        abstract = True
-        base_manager_name = 'objects'
-        if not DJANGO_20_PLUS:
-            manager_inheritance_from_future = True
+        class Meta:
+            # pylint:disable=duplicate-code
+            abstract = True
+            base_manager_name = 'objects'
+            if not DJANGO_20_PLUS:
+                manager_inheritance_from_future = True
 
-    id = SfCharAutoField(primary_key=True, name=SF_PK, db_column='Id', verbose_name='ID', auto_created=True)
+        id = SfCharAutoField(primary_key=True, name=SF_PK, db_column='Id', verbose_name='ID', auto_created=True)
 
-    def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
-        using = using or router.db_for_write(self.__class__, instance=self)
-        if self.pk is None and not force_update and not is_sf_database(using):
-            self.pk = get_sf_alt_pk()
-        super(SalesforceModel, self).save(force_insert=force_insert, force_update=force_update,
-                                          using=using, update_fields=update_fields)
-        if not isinstance(self.pk, str):
-            raise ValueError("The primary key value is not assigned correctly")
+        def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
+            using = using or router.db_for_write(self.__class__, instance=self)
+            if self.pk is None and not force_update and not is_sf_database(using):
+                self.pk = get_sf_alt_pk()
+            super(SalesforceModel, self).save(force_insert=force_insert, force_update=force_update,
+                                              using=using, update_fields=update_fields)
+            if not isinstance(self.pk, str):
+                raise ValueError("The primary key value is not assigned correctly")
 
-    if DJANGO_30_PLUS:
+        if DJANGO_30_PLUS:
 
-        def _do_insert(self, manager, using, fields, returning_fields, raw):
-            # the check "is_sf_database(using)" is used for something unexpected
-            if self.pk and not is_sf_database(using):
-                returning_fields = []
-            return super(SalesforceModel, self)._do_insert(manager, using, fields, returning_fields, raw)
+            def _do_insert(self, manager, using, fields, returning_fields, raw):
+                # the check "is_sf_database(using)" is used for something unexpected
+                if self.pk and not is_sf_database(using):
+                    returning_fields = []
+                return super(SalesforceModel, self)._do_insert(manager, using, fields, returning_fields, raw)

--- a/salesforce/models_extend.py
+++ b/salesforce/models_extend.py
@@ -21,12 +21,11 @@ Interesting not yet implemented ideas are:
 """
 
 from django.db import models, router
-from six import string_types
 
 from salesforce.backend import manager, DJANGO_20_PLUS, DJANGO_30_PLUS
 from salesforce.backend.indep import get_sf_alt_pk
 from salesforce.models import *  # NOQA; pylint:disable=wildcard-import,unused-wildcard-import
-from salesforce.models import SalesforceAutoField, SalesforceModelBase, SF_PK, with_metaclass
+from salesforce.models import SalesforceAutoField, SalesforceModelBase, SF_PK
 from salesforce.router import is_sf_database
 
 
@@ -50,7 +49,7 @@ class SfCharAutoField(SalesforceAutoField):
 
 
 # pylint:disable=too-few-public-methods,function-redefined
-class SalesforceModel(with_metaclass(SalesforceModelBase, models.Model)):
+class SalesforceModel(models.Model, metaclass=SalesforceModelBase):
     """
     Abstract model class for Salesforce objects that can be saved to other db.
 
@@ -77,7 +76,7 @@ class SalesforceModel(with_metaclass(SalesforceModelBase, models.Model)):
             self.pk = get_sf_alt_pk()
         super(SalesforceModel, self).save(force_insert=force_insert, force_update=force_update,
                                           using=using, update_fields=update_fields)
-        if not isinstance(self.pk, string_types):
+        if not isinstance(self.pk, str):
             raise ValueError("The primary key value is not assigned correctly")
 
     if DJANGO_30_PLUS:

--- a/salesforce/models_extend.py
+++ b/salesforce/models_extend.py
@@ -49,7 +49,7 @@ class SfCharAutoField(SalesforceAutoField):
 
 
 # pylint:disable=too-few-public-methods,function-redefined
-class SalesforceModel(models.Model, metaclass=SalesforceModelBase):
+class SalesforceModel(models.Model, metaclass=SalesforceModelBase):  # type: ignore[no-redef] # noqa # redefined
     """
     Abstract model class for Salesforce objects that can be saved to other db.
 

--- a/salesforce/models_template.py
+++ b/salesforce/models_template.py
@@ -43,3 +43,4 @@ DateField = LazyField(salesforce.models.DateField)
 TimeField = LazyField(salesforce.models.TimeField)
 ForeignKey = LazyField(salesforce.models.ForeignKey)
 OneToOneField = LazyField(salesforce.models.OneToOneField)
+AutoField = LazyField(salesforce.models.AutoField)  # not important

--- a/salesforce/models_template.py
+++ b/salesforce/models_template.py
@@ -25,7 +25,7 @@ from salesforce.models import *  # NOQA pylint:disable=unused-wildcard-import,wi
 from salesforce.backend.indep import LazyField
 import salesforce
 
-Model = salesforce.models.ModelTemplate
+Model = salesforce.models.ModelTemplate  # type: ignore[assignment,misc]  # noqa
 
 # pylint: disable=invalid-name
 CharField = LazyField(salesforce.models.CharField)

--- a/salesforce/router.py
+++ b/salesforce/router.py
@@ -9,11 +9,13 @@
 Database router for SalesforceModel objects.
 """
 
+from typing import Optional
 from django.apps import apps
 from django.conf import settings
+from django.db import models
 
 
-def is_sf_database(db, model=None):
+def is_sf_database(db: Optional[str], model: models.Model = None) -> bool:
     """The alias is a Salesforce database."""
     from django.db import connections
     if db is None:

--- a/salesforce/testrunner/example/models.py
+++ b/salesforce/testrunner/example/models.py
@@ -54,7 +54,7 @@ class AbstractAccount(SalesforceModel):
     ]
 
     Owner = models.ForeignKey(User, on_delete=models.DO_NOTHING,
-                              default=User(pk=models.DefaultedOnCreate('')),  # type: ignore
+                              default=User(pk=models.DefaultedOnCreate('')),
                               db_column='OwnerId')
     Type = models.CharField(max_length=100, choices=[(x, x) for x in TYPES],
                             null=True)
@@ -132,7 +132,7 @@ class Contact(SalesforceModel):
     # problematic with migrations in the future because it is not serializable.
     # It can be replaced by normal function.
     owner = models.ForeignKey(User, on_delete=models.DO_NOTHING,
-                              default=User(pk=models.DefaultedOnCreate('')),  # type: ignore
+                              default=User(pk=models.DefaultedOnCreate('')),
                               related_name='contact_owner_set')
 
     def __str__(self):

--- a/salesforce/testrunner/example/models.py
+++ b/salesforce/testrunner/example/models.py
@@ -5,11 +5,8 @@
 # See LICENSE.md for details
 #
 
-from __future__ import absolute_import, unicode_literals
-
 import django
 from django.conf import settings
-from six import python_2_unicode_compatible
 
 from salesforce import models
 from salesforce.models import SalesforceModel as SalesforceModelParent
@@ -45,7 +42,6 @@ class User(SalesforceModel):
     IsActive = models.BooleanField(default=False)
 
 
-@python_2_unicode_compatible
 class AbstractAccount(SalesforceModel):
     """
     Default Salesforce Account model.
@@ -119,7 +115,6 @@ else:
         pass
 
 
-@python_2_unicode_compatible
 class Contact(SalesforceModel):
     # Example that db_column is not necessary for most of fields even with
     # lower case names and for ForeignKey
@@ -142,7 +137,6 @@ class Contact(SalesforceModel):
         return self.name
 
 
-@python_2_unicode_compatible
 class Lead(SalesforceModel):
     """
     Default Salesforce Lead model.
@@ -203,7 +197,6 @@ class Lead(SalesforceModel):
         return self.Name
 
 
-@python_2_unicode_compatible
 class Product(SalesforceModel):
     Name = models.CharField(max_length=255)
 
@@ -214,7 +207,6 @@ class Product(SalesforceModel):
         return self.Name
 
 
-@python_2_unicode_compatible
 class Pricebook(SalesforceModel):
     Name = models.CharField(max_length=255)
 
@@ -225,7 +217,6 @@ class Pricebook(SalesforceModel):
         return self.Name
 
 
-@python_2_unicode_compatible
 class PricebookEntry(SalesforceModel):
     Name = models.CharField(max_length=255, db_column='Name', sf_read_only=models.READ_ONLY)
     Pricebook2 = models.ForeignKey('Pricebook', on_delete=models.DO_NOTHING)

--- a/salesforce/testrunner/example/models.py
+++ b/salesforce/testrunner/example/models.py
@@ -5,7 +5,9 @@
 # See LICENSE.md for details
 #
 
+from typing import Optional
 import django
+import types
 from django.conf import settings
 
 from salesforce import models
@@ -111,7 +113,7 @@ if getattr(settings, 'PERSON_ACCOUNT_ACTIVATED', False):
     class Account(PersonAccount):  # pylint:disable=model-no-explicit-unicode
         pass
 else:
-    class Account(CoreAccount):    # pylint:disable=model-no-explicit-unicode
+    class Account(CoreAccount):  # type: ignore[no-redef]  # noqa # pylint:disable=model-no-explicit-unicode
         pass
 
 
@@ -286,8 +288,9 @@ class Note(models.Model):
 
 class Opportunity(SalesforceModel):
     name = models.CharField(max_length=255)
-    contacts = django.db.models.ManyToManyField(Contact, through='example.OpportunityContactRole',
-                                                related_name='opportunities')
+    contacts = django.db.models.ManyToManyField(
+        Contact, through='example.OpportunityContactRole', related_name='opportunities'
+    )
     close_date = models.DateField()
     stage = models.CharField(max_length=255, db_column='StageName')  # e.g. "Prospecting"
     created_date = models.DateTimeField(sf_read_only=models.READ_ONLY)
@@ -304,6 +307,7 @@ class OpportunityContactRole(SalesforceModel):
 
 
 try:
+    models_template = None  # type: Optional[types.ModuleType]
     from salesforce.testrunner.example import models_template
 except ImportError:
     # this is useful for the case that the model is being rewritten by inspectdb

--- a/salesforce/testrunner/example/models.py
+++ b/salesforce/testrunner/example/models.py
@@ -54,7 +54,7 @@ class AbstractAccount(SalesforceModel):
     ]
 
     Owner = models.ForeignKey(User, on_delete=models.DO_NOTHING,
-                              default=models.DEFAULTED_ON_CREATE,
+                              default=User(pk=models.DefaultedOnCreate('')),  # type: ignore
                               db_column='OwnerId')
     Type = models.CharField(max_length=100, choices=[(x, x) for x in TYPES],
                             null=True)
@@ -132,7 +132,7 @@ class Contact(SalesforceModel):
     # problematic with migrations in the future because it is not serializable.
     # It can be replaced by normal function.
     owner = models.ForeignKey(User, on_delete=models.DO_NOTHING,
-                              default=models.DEFAULTED_ON_CREATE,
+                              default=User(pk=models.DefaultedOnCreate('')),  # type: ignore
                               related_name='contact_owner_set')
 
     def __str__(self):

--- a/salesforce/testrunner/example/models.py
+++ b/salesforce/testrunner/example/models.py
@@ -54,7 +54,7 @@ class AbstractAccount(SalesforceModel):
     ]
 
     Owner = models.ForeignKey(User, on_delete=models.DO_NOTHING,
-                              default=User(pk=models.DefaultedOnCreate('')),
+                              default=models.DefaultedOnCreate(User),
                               db_column='OwnerId')
     Type = models.CharField(max_length=100, choices=[(x, x) for x in TYPES],
                             null=True)
@@ -132,7 +132,7 @@ class Contact(SalesforceModel):
     # problematic with migrations in the future because it is not serializable.
     # It can be replaced by normal function.
     owner = models.ForeignKey(User, on_delete=models.DO_NOTHING,
-                              default=User(pk=models.DefaultedOnCreate('')),
+                              default=models.DefaultedOnCreate(User),
                               related_name='contact_owner_set')
 
     def __str__(self):
@@ -186,7 +186,7 @@ class Lead(SalesforceModel):
     # Deleted object can be found only in querysets with "query_all" SF method.
     IsDeleted = models.BooleanField(default=False, sf_read_only=models.READ_ONLY)
     owner = models.ForeignKey(User, on_delete=models.DO_NOTHING,
-                              default=models.DEFAULTED_ON_CREATE,
+                              default=models.DefaultedOnCreate(User),
                               related_name='lead_owner_set')
     last_modified_by = models.ForeignKey(User, on_delete=models.DO_NOTHING, null=True,
                                          sf_read_only=models.READ_ONLY,

--- a/salesforce/testrunner/example/models.py
+++ b/salesforce/testrunner/example/models.py
@@ -123,7 +123,7 @@ class Contact(SalesforceModel):
     account = models.ForeignKey(Account, on_delete=models.DO_NOTHING,
                                 blank=True, null=True)  # db_column: 'AccountId'
     last_name = models.CharField(max_length=80)
-    first_name = models.CharField(max_length=40, blank=True)
+    first_name = models.CharField(max_length=40, blank=True, null=True)
     name = models.CharField(max_length=121, sf_read_only=models.READ_ONLY,
                             verbose_name='Full Name')
     email = models.EmailField(blank=True, null=True)

--- a/salesforce/testrunner/example/models_template.py
+++ b/salesforce/testrunner/example/models_template.py
@@ -4,7 +4,6 @@ Shortened due to readability:
 removed very long choices, removed many long fields, reformated long
 lines, but still an example of a long model exported from Salesforce.
 """
-from __future__ import unicode_literals
 from salesforce import models_template as models
 
 

--- a/salesforce/testrunner/settings.py
+++ b/salesforce/testrunner/settings.py
@@ -26,6 +26,7 @@ DATABASES = {
         'HOST': 'https://login.salesforce.com',
         'TEST': {
             'DEPENDENCIES': [],
+            'MIGRATE': False,   # to run tests without migrations in Django 3.1+
         },
     }
 }  # type: Dict[str, Any]

--- a/salesforce/testrunner/settings.py
+++ b/salesforce/testrunner/settings.py
@@ -1,5 +1,5 @@
 # Django settings for testrunner project.
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 import os
 
 DEBUG = True
@@ -101,7 +101,7 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
-ROOT_URLCONF = 'salesforce.testrunner.urls'
+ROOT_URLCONF = 'salesforce.testrunner.urls'  # type: Optional[str]
 
 TEMPLATES = [
     {

--- a/salesforce/testrunner/settings.py
+++ b/salesforce/testrunner/settings.py
@@ -1,4 +1,5 @@
 # Django settings for testrunner project.
+from typing import Any, Dict, Tuple, Union
 import os
 
 DEBUG = True
@@ -24,7 +25,7 @@ DATABASES = {
         'PASSWORD': os.environ.get('SF_PASSWORD', ''),
         'HOST': 'https://login.salesforce.com',
     }
-}
+}  # type: Dict[str, Any]
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
@@ -131,7 +132,7 @@ INSTALLED_APPS = (
 
 SALESFORCE_DB_ALIAS = 'salesforce'
 # Timeouts tuple: (waiting for connection, waiting for data) in seconds
-SALESFORCE_QUERY_TIMEOUT = (4, 15)
+SALESFORCE_QUERY_TIMEOUT = (4, 15)  # type: Union[float, Tuple[float, float]]
 # Maximal number of retries after timeout.
 # REQUESTS_MAX_RETRIES = 1
 DATABASE_ROUTERS = [

--- a/salesforce/testrunner/settings.py
+++ b/salesforce/testrunner/settings.py
@@ -24,6 +24,9 @@ DATABASES = {
         'USER': os.environ.get('SF_USER', ''),
         'PASSWORD': os.environ.get('SF_PASSWORD', ''),
         'HOST': 'https://login.salesforce.com',
+        'TEST': {
+            'DEPENDENCIES': [],
+        },
     }
 }  # type: Dict[str, Any]
 

--- a/salesforce/testrunner/settings.py
+++ b/salesforce/testrunner/settings.py
@@ -120,7 +120,7 @@ TEMPLATES = [
     },
 ]
 
-INSTALLED_APPS = (
+INSTALLED_APPS = [
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
@@ -131,7 +131,7 @@ INSTALLED_APPS = (
     'django.contrib.admindocs',
     'salesforce',
     'salesforce.testrunner.example',
-)
+]
 
 SALESFORCE_DB_ALIAS = 'salesforce'
 # Timeouts tuple: (waiting for connection, waiting for data) in seconds

--- a/salesforce/tests/test_auth.py
+++ b/salesforce/tests/test_auth.py
@@ -48,3 +48,4 @@ class OAuthTest(TestCase):
         self.validate_oauth(auth.oauth_data[sf_alias])
 
         self.assertEqual(old_data[sf_alias]['access_token'], auth.oauth_data[sf_alias]['access_token'])
+        _session.close()

--- a/salesforce/tests/test_doc_tests.py
+++ b/salesforce/tests/test_doc_tests.py
@@ -1,11 +1,13 @@
-def doc_tests():
-    """Doctests that can be selected by 'manage.py test thismodule.doctests'"""
-    import doctest
-    return doctest.DocTestSuite('salesforce.backend.introspection')
+"""Doctests that can be selected by 'manage.py test thismodule.doctests'"""
+import doctest
+
+doc_tests = [
+    doctest.DocTestSuite('salesforce.backend.introspection'),
+]
 
 
 def load_tests(loader, tests, ignore):
     """Add doctests to unittests"""
     # pylint:disable=invalid-name,unused-argument
-    tests.addTests(doc_tests())
+    tests.addTests(doc_tests)
     return tests

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -263,7 +263,8 @@ class BasicSOQLRoTest(TestCase, LazyTestMixin):
                 with QuietSalesforceErrors(sf_alias):
                     duplicate.save()
             except salesforce.backend.base.SalesforceError as exc:
-                self.assertEqual(exc.data[0]['errorCode'], 'DUPLICATE_VALUE')
+                # TODO uncovered line, baybe bug
+                self.assertEqual(exc.data[0]['errorCode'], 'DUPLICATE_VALUE')  # type: ignore
             else:
                 self.assertRaises(salesforce.backend.base.SalesforceError, duplicate.save)
 

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -836,7 +836,7 @@ class BasicSOQLRoTest(TestCase, LazyTestMixin):
         self.assertNotIn('attributes', values[0])
         self.assertEqual(len(values[0]), 3)
         if default_is_sf:
-            self.assertRegexpMatches(values[0]['pk'], '^003')
+            self.assertRegex(values[0]['pk'], '^003')
 
         values_list = Contact.objects.values_list('pk', 'first_name', 'last_name')[:2]
         self.assertEqual(len(values_list), 2)
@@ -1043,7 +1043,7 @@ class BasicSOQLRoTest(TestCase, LazyTestMixin):
                     last_modified_by__Username=current_user)
             )
             sql, params = qs.query.get_compiler('salesforce').as_sql()
-            self.assertRegexpMatches(sql, r'SELECT Task.Id, .* FROM Task WHERE Task.WhoId IN \(SELECT ')
+            self.assertRegex(sql, r'SELECT Task.Id, .* FROM Task WHERE Task.WhoId IN \(SELECT ')
             self.assertIn('Lead.Owner.Username = %s', sql)
             self.assertIn('Lead.LastModifiedBy.Username = %s', sql)
             refreshed_lead = qs[:1]
@@ -1067,9 +1067,9 @@ class BasicSOQLRoTest(TestCase, LazyTestMixin):
         try:
             qs = contact.opportunities.all()
             sql, params = qs.query.get_compiler('salesforce').as_sql()
-            self.assertRegexpMatches(sql,
-                                     r'SELECT .*OpportunityContactRole\.Opportunity\.StageName.* '
-                                     'FROM OpportunityContactRole WHERE OpportunityContactRole.ContactId =')
+            self.assertRegex(sql,
+                             r'SELECT .*OpportunityContactRole\.Opportunity\.StageName.* '
+                             'FROM OpportunityContactRole WHERE OpportunityContactRole.ContactId =')
             self.assertEqual([x.pk for x in qs], 2 * [oppo.pk])
         finally:
             oc2.delete()

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -264,8 +264,8 @@ class BasicSOQLRoTest(TestCase, LazyTestMixin):
                 self.assertRaises(salesforce.backend.base.SalesforceError, duplicate.save)
 
             # test 2: the reverse relation is a value, not a set
-            result = User.objects.exclude(apex_email_notification__user=None)
-            self.assertIn(current_user, [x.Username for x in result])
+            users = User.objects.exclude(apex_email_notification__user=None)
+            self.assertIn(current_user, [x.Username for x in users])
 
             # test 3: relation to the parent
             result = ApexEmailNotification.objects.filter(user__Username=notifier_u.user.Username)
@@ -821,15 +821,18 @@ class BasicSOQLRoTest(TestCase, LazyTestMixin):
             self.assertRaises(salesforce.backend.base.SalesforceError, list, bad_queryset)
 
     def test_queryset_values(self):
-        """Test list of dict qs.values() and list of tuples qs.values_list()
+        """Test list of dict qs.values()
         """
-        tmp = Contact.objects.values('pk', 'last_name')
-        tmp[0]
         values = Contact.objects.values()[:2]
         self.assertEqual(len(values), 2)
         self.assertIn('first_name', values[0])
         self.assertGreater(len(values[0]), 3)
 
+    def test_queryset_values_names(self):
+        """Test list of dict qs.values(*names) and list of tuples qs.values_list()
+        """
+        tmp = Contact.objects.values('pk', 'last_name')
+        tmp[0]
         values = Contact.objects.values('pk', 'first_name', 'last_name')[:2]
         self.assertEqual(len(values), 2)
         self.assertIn('first_name', values[0])

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -17,10 +17,10 @@ import warnings
 import pytz
 from django.conf import settings
 from django.db import connections
-from django.db.models import Q, Avg, Count, Sum, Min, Max
+from django.db.models import Q, Avg, Count, Sum, Min, Max, Model, query as models_query
 from django.test import TestCase
 from django.utils import timezone
-from typing import List
+from typing import List, TypeVar
 
 import salesforce
 from salesforce import router
@@ -41,6 +41,8 @@ from salesforce.testrunner.example.models import (
 
 log = logging.getLogger(__name__)
 
+_M = TypeVar('_M', bound=Model)
+
 QUIET_KNOWN_BUGS = strtobool(os.getenv('QUIET_KNOWN_BUGS', 'false'))
 test_email = 'test-djsf-unittests%s@example.com' % uid
 sf_databases = [db for db in connections if router.is_sf_database(db)]
@@ -59,7 +61,8 @@ def refresh(obj):
     """Get the same object refreshed from the same db.
     """
     db = obj._state.db
-    return type(obj).objects.using(db).get(pk=obj.pk)
+    qs = type(obj).objects.using(db)  # type: models_query.QuerySet[_M]
+    return qs.get(pk=obj.pk)
 
 
 class BasicSOQLRoTest(TestCase, LazyTestMixin):

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -827,7 +827,7 @@ class BasicSOQLRoTest(TestCase, LazyTestMixin):
     def test_group_by_compile(self) -> None:
         """Test that group annotations can be correctly compiled and executed"""
         qs = (Contact.objects.filter(account__Name__gt='').order_by()
-              .values('account_id').annotate(cnt=Count('id'))
+              .values('account_id').annotate(cnt=Count('pk'))
               )
         soql, params = qs.query.get_compiler('salesforce').as_sql()
         expected_soql = (

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -20,6 +20,7 @@ from django.db import connections
 from django.db.models import Q, Avg, Count, Sum, Min, Max
 from django.test import TestCase
 from django.utils import timezone
+from typing import List
 
 import salesforce
 from salesforce import router
@@ -44,7 +45,7 @@ QUIET_KNOWN_BUGS = strtobool(os.getenv('QUIET_KNOWN_BUGS', 'false'))
 test_email = 'test-djsf-unittests%s@example.com' % uid
 sf_databases = [db for db in connections if router.is_sf_database(db)]
 
-_sf_tables = []
+_sf_tables = []  # type: List[str]
 
 
 def sf_tables():

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -402,8 +402,18 @@ class BasicSOQLRoTest(TestCase, LazyTestMixin):
         field should not cause a problem.
         """
         oppo = Opportunity(name='test op', stage='Prospecting', close_date=datetime.date.today())
-        oppo.save()
         try:
+            oppo.save()
+            with self.assertWarns(SalesforceWarning):
+                # should save a DEFAULTED_ON_CREATE field 'probability' on update, but with warning
+                oppo.save()
+
+            oppo.save(update_fields=['name', 'stage'])
+            with self.assertWarns(SalesforceWarning):
+                oppo.save(update_fields=['name', 'stage', 'probability'])
+
+            # a normal value can be saved on update
+            oppo.probability = '25'  # percent
             oppo.save()
         finally:
             oppo.delete()

--- a/salesforce/tests/test_unit.py
+++ b/salesforce/tests/test_unit.py
@@ -106,16 +106,16 @@ class TestQueryCompiler(TestCase, LazyTestMixin):
             opportunity__in=Opportunity.objects.filter(stage='Prospecting')
         )
         sql, params = qs.query.get_compiler('salesforce').as_sql()
-        self.assertRegexpMatches(sql,
-                                 "WHERE Opportunity.StageName =",
-                                 "Probably because aliases are invalid for SFDC, e.g. 'U0.StageName'")
-        self.assertRegexpMatches(sql,
-                                 r'SELECT .*OpportunityContactRole\.Role.* '
-                                 r'FROM OpportunityContactRole WHERE \(.* AND .*\)')
-        self.assertRegexpMatches(sql,
-                                 r'OpportunityContactRole.OpportunityId IN '
-                                 r'\(SELECT Opportunity\.Id FROM Opportunity WHERE Opportunity\.StageName = %s ?\)')
-        self.assertRegexpMatches(sql, 'OpportunityContactRole.Role = %s')
+        self.assertRegex(sql,
+                         "WHERE Opportunity.StageName =",
+                         "Probably because aliases are invalid for SFDC, e.g. 'U0.StageName'")
+        self.assertRegex(sql,
+                         r'SELECT .*OpportunityContactRole\.Role.* '
+                         r'FROM OpportunityContactRole WHERE \(.* AND .*\)')
+        self.assertRegex(sql,
+                         r'OpportunityContactRole.OpportunityId IN '
+                         r'\(SELECT Opportunity\.Id FROM Opportunity WHERE Opportunity\.StageName = %s ?\)')
+        self.assertRegex(sql, 'OpportunityContactRole.Role = %s')
 
     def test_none_method_queryset(self):
         """Test that none() method in the queryset returns [], not error"""

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [flake8]
 max_line_length=119
-exclude=.git,.tox,.env,build,models1*.py,packages_,tests/inspectdb/models.py,tests/tooling/models.py
+exclude=.git,.tox,.env,build,models1*.py,packages_,tests/inspectdb/models.py,tests/inspectdb/dependent_model/models_template.py,tests/tooling/models.py

--- a/setup.py
+++ b/setup.py
@@ -37,10 +37,10 @@ def get_tagged_version():
 def autosetup():
     from setuptools import setup, find_packages
 
-    with open(relative_path('requirements.txt'), 'rU') as f:
+    with open(relative_path('requirements.txt'), 'r', newline=None) as f:
         requirements_txt = f.read().split("\n")
 
-    with open(relative_path('README.rst'), 'rU') as f:
+    with open(relative_path('README.rst'), 'r', newline=None) as f:
         long_description = f.read()
 
     # check if installed with git data (not via PyPi)

--- a/tests/inspectdb/admin.py
+++ b/tests/inspectdb/admin.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from salesforce.testrunner.example.universal_admin import register_omitted_classes
 from . import models
 

--- a/tests/inspectdb/dependent_model/models.py
+++ b/tests/inspectdb/dependent_model/models.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from salesforce import models
 
 from tests.inspectdb.dependent_model import models_template
@@ -9,7 +8,7 @@ class User(models.Model):
 
 
 class Organization(models.Model):
-    # all fields are copie dynamically
+    # all fields are copied dynamically
     class Meta:
         db_table = 'Organization'
         dynamic_field_patterns = models_template, ['.*']

--- a/tests/inspectdb/dependent_model/models.py
+++ b/tests/inspectdb/dependent_model/models.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 from salesforce import models
 
-from tests.inspectdb import models as models_template
+from tests.inspectdb.dependent_model import models_template
 
 
 class User(models.Model):

--- a/tests/inspectdb/dependent_model/settings.py
+++ b/tests/inspectdb/dependent_model/settings.py
@@ -1,8 +1,8 @@
 from salesforce.testrunner.settings import *  # NOQA
 from salesforce.testrunner.settings import INSTALLED_APPS
 
-INSTALLED_APPS = tuple(x for x in INSTALLED_APPS if not x.startswith('salesforce.testrunner.'))
+INSTALLED_APPS = [x for x in INSTALLED_APPS if not x.startswith('salesforce.testrunner.')]
 # INSTALLED_APPS += ('tests.inspectdb', 'tests.inspectdb.dependent_model')
-INSTALLED_APPS += ('tests.inspectdb.dependent_model.AutoModelConf',
-                   'tests.inspectdb.dependent_model.DependentModelConf')
+INSTALLED_APPS += ['tests.inspectdb.dependent_model.AutoModelConf',
+                   'tests.inspectdb.dependent_model.DependentModelConf']
 ROOT_URLCONF = None

--- a/tests/inspectdb/settings.py
+++ b/tests/inspectdb/settings.py
@@ -2,6 +2,6 @@ from salesforce.testrunner.settings import *  # NOQA pylint: disable=unused-wild
 from salesforce.testrunner.settings import INSTALLED_APPS
 
 # replace the test app
-INSTALLED_APPS = tuple(x for x in INSTALLED_APPS if not x.startswith('salesforce.testrunner.'))
-INSTALLED_APPS += ('tests.inspectdb',)
+INSTALLED_APPS = [x for x in INSTALLED_APPS if not x.startswith('salesforce.testrunner.')]
+INSTALLED_APPS += ['tests.inspectdb']
 ROOT_URLCONF = 'tests.inspectdb.urls'

--- a/tests/inspectdb/settings.py
+++ b/tests/inspectdb/settings.py
@@ -4,4 +4,4 @@ from salesforce.testrunner.settings import INSTALLED_APPS
 # replace the test app
 INSTALLED_APPS = tuple(x for x in INSTALLED_APPS if not x.startswith('salesforce.testrunner.'))
 INSTALLED_APPS += ('tests.inspectdb',)
-ROOT_URLCONF = None
+ROOT_URLCONF = 'tests.inspectdb.urls'

--- a/tests/inspectdb/test.sh
+++ b/tests/inspectdb/test.sh
@@ -30,12 +30,16 @@ if python manage.py inspectdb --database=salesforce --traceback >tests/inspectdb
     RESULT_3=$?
 
     echo "*** dependent dynamic model test ***"
+    sed 's/import models$/import models_template as models/' tests/inspectdb/models.py \
+        >tests/inspectdb/dependent_model/models_template.py
+    DJANGO_SETTINGS_MODULE=tests.inspectdb.dependent_model.settings python manage.py check
+    RESULT_4=$?
     DJANGO_SETTINGS_MODULE=tests.inspectdb.dependent_model.settings python -m unittest tests.inspectdb.dependent_model.test
     #python manage.py test --settings=tests.inspectdb.settings tests.inspectdb
-    RESULT_4=$?
+    RESULT_5=$?
 
     echo -en "\nSummary: "
-    if [ $RESULT_1 == 0 -a $RESULT_2 == 0 -a $RESULT_3 == 0 -a $RESULT_4 == 0 ]; then
+    if [ $RESULT_1 == 0 -a $RESULT_2 == 0 -a $RESULT_3 == 0 -a $RESULT_4 == 0 -a $RESULT_5 == 0 ]; then
         echo OK
     else
         echo ERROR

--- a/tests/inspectdb/test.sh
+++ b/tests/inspectdb/test.sh
@@ -9,7 +9,7 @@
 
 
 echo "python manage.py inspectdb --database=salesforce >tests/inspectdb/models.py"
-if python manage.py inspectdb --database=salesforce --traceback >tests/inspectdb/models.py; then
+if python manage.py inspectdb --database=salesforce --concise-db-column --traceback >tests/inspectdb/models.py; then
 
     # Run both tests even if the first test fails. With old Django versions can
     # the read/write test pass (useful information) though validation failed.

--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -2,20 +2,21 @@
 
 test of a dependent module.
 """
+from collections import OrderedDict
+from typing import Dict
 import os
 import re
 import unittest
-from collections import OrderedDict
 
 
-def relative_path(path):
+def relative_path(path: str) -> str:
     """
     Return the given path relative to this file.
     """
     return os.path.join(os.path.dirname(__file__), path)
 
 
-def get_classes_texts():
+def get_classes_texts() -> Dict[str, str]:
     """
     Get classes texts as a dict.
     """
@@ -29,20 +30,22 @@ def get_classes_texts():
         for text in f.read().split('\n\n'):
             text = text.strip()
             if text and not excluded_pattern.match(text):
-                class_name = re.match(r'class (\w+)\(', text).groups()[0]
+                match = re.match(r'class (\w+)\(', text)
+                assert match
+                class_name = match.groups()[0]
                 result[class_name] = text
     return result
 
 
 class ExportedModelTest(unittest.TestCase):
 
-    def match_line(self, pattern, text):
+    def match_line(self, pattern, text) -> str:
         """requires the pattern and finds the line"""
         self.assertRegex(text, pattern)
         (ret,) = [line for line in text.split('\n') if re.match(pattern, line)]
         return ret
 
-    def test_nice_fields_names(self):
+    def test_nice_fields_names(self) -> None:
         """Test the typical nice field name 'last_modified_date'."""
         for text in classes_texts.values():
             if re.search(r' last_modified_date = ', text):
@@ -55,7 +58,7 @@ class ExportedModelTest(unittest.TestCase):
     def test_nice_standard_class_name(self):
         self.assertTrue('AccountContactRole' in classes_texts.keys())
 
-    def test_custom_test_class(self):
+    def test_custom_test_class(self) -> None:
         """Test the typical nice class name 'Test'."""
         for name, text in classes_texts.items():
             if re.search(r"        db_table = 'django_Test__c'", text):
@@ -71,7 +74,7 @@ class ExportedModelTest(unittest.TestCase):
         else:
             self.skipTest("The model for the table Test__c not exported.")
 
-    def test_master_detail_relationship(self):
+    def test_master_detail_relationship(self) -> None:
         """
         Verify that Contact is a master-detail relationship of Account,
         but Opportunity is not.

--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -7,8 +7,6 @@ import re
 import unittest
 from collections import OrderedDict
 
-from six import assertRegex
-
 
 def relative_path(path):
     """
@@ -40,7 +38,7 @@ class ExportedModelTest(unittest.TestCase):
 
     def match_line(self, pattern, text):
         """requires the pattern and finds the line"""
-        assertRegex(self, text, pattern)
+        self.assertRegex(text, pattern)
         (ret,) = [line for line in text.split('\n') if re.match(pattern, line)]
         return ret
 
@@ -79,7 +77,7 @@ class ExportedModelTest(unittest.TestCase):
         but Opportunity is not.
         """
         line = self.match_line('    account = ', classes_texts['Contact'])
-        assertRegex(self, line, r'#.* Master Detail Relationship \*')
+        self.assertRegex(line, r'#.* Master Detail Relationship \*')
         line = self.match_line('    created_by = ', classes_texts['Opportunity'])
         self.assertNotIn('Master Detail Relationship', line)
 

--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -26,7 +26,7 @@ def get_classes_texts() -> Dict[str, str]:
                                   r'# This is an auto-generated Django model|'
                                   r'from salesforce import models$'
                                   r')')
-    with open(relative_path('models.py'), 'rU') as f:
+    with open(relative_path('models.py'), 'r', newline=None) as f:
         for text in f.read().split('\n\n'):
             text = text.strip()
             if text and not excluded_pattern.match(text):

--- a/tests/inspectdb/urls.py
+++ b/tests/inspectdb/urls.py
@@ -1,0 +1,10 @@
+from django.contrib import admin
+from salesforce.backend import DJANGO_20_PLUS
+if DJANGO_20_PLUS:
+    from django.urls import path
+else:
+    from django.conf.urls import url as path
+
+urlpatterns = [
+    path('admin/', admin.site.urls),
+]

--- a/tests/mypy.sh
+++ b/tests/mypy.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+RET=0
+MORE_TESTS=tests/inspectdb
+for x in tests/test_* $MORE_TESTS; do
+    if test -e $x/test.sh; then
+        if test -e $x/mypy.ini; then
+            CONFIG=$x/mypy.ini
+        else
+            CONFIG=mypy.ini
+        fi
+	echo "== .tox/typing/bin/mypy --config-file=$CONFIG $x $@ =="
+        .tox/typing/bin/mypy --config-file=$CONFIG $x $@ || RET=$?
+    fi
+done
+test $RET -eq 0

--- a/tests/t_debug_toolbar/tests.py
+++ b/tests/t_debug_toolbar/tests.py
@@ -1,5 +1,4 @@
 """Test with django-debug-toolbar."""
-from __future__ import absolute_import
 from django.test import TestCase, override_settings
 import django.contrib.auth
 from salesforce.backend.test_helpers import uid_version as uid

--- a/tests/t_debug_toolbar/tests.py
+++ b/tests/t_debug_toolbar/tests.py
@@ -1,8 +1,9 @@
 """Test with django-debug-toolbar."""
+import datetime
 from django.test import TestCase, override_settings
 import django.contrib.auth
-from salesforce.backend.test_helpers import uid_version as uid
-from salesforce.testrunner.example.models import Campaign
+from salesforce.backend.test_helpers import uid_version as uid, expectedFailure
+from salesforce.testrunner.example.models import Campaign, Contact, Lead, Opportunity
 
 
 @override_settings(DEBUG=True)
@@ -34,4 +35,39 @@ class DebugToolbarAdminTest(TestCase):
         resp = self.client.post('/admin/example/campaign/add/', {'name': 'test_' + uid})
         self.assertEqual(resp.status_code, 302, "Object not created")
         count_deleted, _ = Campaign.objects.filter(name='test_' + uid).delete()
+        self.assertEqual(count_deleted, 1)
+
+    def test_defaulted_numeric_create(self):
+        """A simple object with a simple DefaultedOnCreate can be easily filled by web client and saved"""
+        # it works becase
+        resp = self.client.post(
+            '/admin/example/opportunity/add/',
+            dict(name='test_' + uid, stage='Prospecting', close_date=datetime.date.today())
+        )
+        self.assertEqual(resp.status_code, 302, "Object not created")
+        opportunities = Opportunity.objects.filter(name='test_' + uid)
+
+        # # this must fail because the DefaultedOnCreate can not pass through a web form
+        # self.assertGreater(opportunities[0].probability, 0)
+
+        count_deleted, _ = opportunities.delete()
+        self.assertEqual(count_deleted, 1)
+
+    @expectedFailure
+    # This fails currently: not enough valid data for this web form because Lead object
+    # has many reguired fields. This Lead object is not a good example for web tests.
+    # However i works if all required fields are filled manually.
+    def test_defaulted_bool_create(self):
+        resp = self.client.post('/admin/example/lead/add/', dict(Company='test_' + uid, LastName='some lastname'))
+        self.assertEqual(resp.status_code, 302, "Object not created")
+        count_deleted, _ = Lead.objects.filter(Company='test_' + uid).delete()
+        self.assertEqual(count_deleted, 1)
+
+    @expectedFailure
+    # A form with ForeignKey with DefaultedOnCreate fails, because the web widget requires
+    # o concrete foreign key value and the object will be not saved.
+    def test_defaulted_foreignkey_create(self):
+        resp = self.client.post('/admin/example/contact/add/', dict(last_name='test_' + uid))
+        self.assertEqual(resp.status_code, 302, "Object not created")
+        count_deleted, _ = Contact.objects.filter(Company='test_' + uid).delete()
         self.assertEqual(count_deleted, 1)

--- a/tests/t_debug_toolbar/urls.py
+++ b/tests/t_debug_toolbar/urls.py
@@ -1,4 +1,4 @@
-import debug_toolbar
+import debug_toolbar  # type: ignore[import] # noqa
 from django.urls import include, path
 from salesforce.testrunner.urls import urlpatterns
 from .views import account_insert_delete

--- a/tests/t_debug_toolbar/views.py
+++ b/tests/t_debug_toolbar/views.py
@@ -1,12 +1,11 @@
 from django.http import HttpResponse
-from salesforce.backend.test_helpers import current_user
 from salesforce.testrunner.example import models
 
 
 def account_insert_delete(request):
     # simple test view for debug-toolbar
-    user = models.User.objects.get(Username=current_user)
-    account = models.Account(Name='abc', Owner=user)
+    # Owner field is prepared by DefaultedOnCreate in the Account model
+    account = models.Account(Name='abc')
     account.save()
     account.Name = 'xyz'
     account.save()

--- a/tests/t_debug_toolbar/views.py
+++ b/tests/t_debug_toolbar/views.py
@@ -1,10 +1,12 @@
 from django.http import HttpResponse
+from salesforce.backend.test_helpers import current_user
 from salesforce.testrunner.example import models
 
 
 def account_insert_delete(request):
     # simple test view for debug-toolbar
-    account = models.Account(Name='abc')
+    user = models.User.objects.get(Username=current_user)
+    account = models.Account(Name='abc', Owner=user)
     account.save()
     account.Name = 'xyz'
     account.save()

--- a/tests/test_app_label/salesforce/tests.py
+++ b/tests/test_app_label/salesforce/tests.py
@@ -1,5 +1,4 @@
 """Backward compatible behaviour with primary key 'Id'."""
-from __future__ import absolute_import
 from django.test import TestCase
 from .models import Contact
 

--- a/tests/test_app_label/settings.py
+++ b/tests/test_app_label/settings.py
@@ -1,5 +1,4 @@
 """Test that app config can override a directory name conflict (.e.g. "salesforce")"""
-from __future__ import absolute_import
 from salesforce.testrunner.settings import *  # NOQA pylint: disable=unused-wildcard-import,wildcard-import
 from salesforce.testrunner.settings import INSTALLED_APPS
 

--- a/tests/test_app_label/settings.py
+++ b/tests/test_app_label/settings.py
@@ -2,6 +2,6 @@
 from salesforce.testrunner.settings import *  # NOQA pylint: disable=unused-wildcard-import,wildcard-import
 from salesforce.testrunner.settings import INSTALLED_APPS
 
-INSTALLED_APPS = tuple(x for x in INSTALLED_APPS if x != 'salesforce.testrunner.example')
-INSTALLED_APPS += ('tests.test_app_label.salesforce.apps.TestSalesForceConfig',)
+INSTALLED_APPS = [x for x in INSTALLED_APPS if x != 'salesforce.testrunner.example']
+INSTALLED_APPS += ['tests.test_app_label.salesforce.apps.TestSalesForceConfig']
 ROOT_URLCONF = None

--- a/tests/test_compatibility/models.py
+++ b/tests/test_compatibility/models.py
@@ -13,4 +13,4 @@ class Lead(SalesforceModel):
     Company = models.CharField(max_length=255)
     LastName = models.CharField(max_length=80)
     Owner = models.ForeignKey(User, on_delete=models.DO_NOTHING,
-                              default=lambda: User(Id='DEFAULT'), db_column='OwnerId')
+                              default=models.DEFAULTED_ON_CREATE, db_column='OwnerId')

--- a/tests/test_compatibility/settings.py
+++ b/tests/test_compatibility/settings.py
@@ -1,7 +1,7 @@
 from salesforce.testrunner.settings import *  # NOQA pylint: disable=unused-wildcard-import,wildcard-import
 from salesforce.testrunner.settings import INSTALLED_APPS
 
-INSTALLED_APPS = tuple(x for x in INSTALLED_APPS if x != 'salesforce.testrunner.example')
-INSTALLED_APPS += ('tests.test_compatibility',)
+INSTALLED_APPS = [x for x in INSTALLED_APPS if x != 'salesforce.testrunner.example']
+INSTALLED_APPS += ['tests.test_compatibility']
 SF_PK = 'Id'
 ROOT_URLCONF = None

--- a/tests/test_compatibility/tests.py
+++ b/tests/test_compatibility/tests.py
@@ -1,5 +1,4 @@
 """Backward compatible behaviour with primary key 'Id'."""
-from __future__ import absolute_import
 from django.test import TestCase
 from tests.test_compatibility.models import Lead
 from salesforce.backend.test_helpers import current_user, uid_version as uid

--- a/tests/test_default_db/settings.py
+++ b/tests/test_default_db/settings.py
@@ -1,7 +1,7 @@
 from salesforce.testrunner.settings import *  # NOQA pylint: disable=unused-wildcard-import,wildcard-import
 from salesforce.testrunner.settings import DATABASES
 
-INSTALLED_APPS = ('tests.test_default_db',)
+INSTALLED_APPS = ['tests.test_default_db']
 DATABASES = {'default': DATABASES['default'], 'salesforce': DATABASES['salesforce']}
 SALESFORCE_DB_ALIAS = 'default'
 ROOT_URLCONF = None

--- a/tests/test_default_db/tests.py
+++ b/tests/test_default_db/tests.py
@@ -1,5 +1,4 @@
 """Test djangoBackward compatible behaviour with primary key 'Id'."""
-from __future__ import absolute_import
 from django.test import TestCase
 
 from .models import Account, Contact

--- a/tests/test_migrate/models.py
+++ b/tests/test_migrate/models.py
@@ -4,6 +4,14 @@ from salesforce import models
 from salesforce.models import SalesforceModel
 
 
+class User(SalesforceModel):
+    username = models.CharField(max_length=80)
+    email = models.CharField(max_length=100)
+    last_name = models.CharField(max_length=80)
+    first_name = models.CharField(max_length=40, null=True, blank=True)
+    is_active = models.BooleanField(default=False)
+
+
 class Lead(SalesforceModel):
     company = models.CharField(max_length=255)
     last_name = models.CharField(max_length=80)
@@ -14,6 +22,7 @@ class Lead(SalesforceModel):
 
 class Contact(SalesforceModel):
     last_name = models.CharField(max_length=80)
+    owner = models.ForeignKey(User, on_delete=models.DO_NOTHING, default=models.DefaultedOnCreate(User))
 
     class Meta:
         managed = True

--- a/tests/test_migrate/settings.py
+++ b/tests/test_migrate/settings.py
@@ -1,8 +1,8 @@
 from salesforce.testrunner.settings import *  # NOQA pylint: disable=unused-wildcard-import,wildcard-import
 from salesforce.testrunner.settings import INSTALLED_APPS
 
-INSTALLED_APPS = tuple(x for x in INSTALLED_APPS if x != 'salesforce.testrunner.example')
-INSTALLED_APPS += ('tests.test_migrate',)
+INSTALLED_APPS = [x for x in INSTALLED_APPS if x != 'salesforce.testrunner.example']
+INSTALLED_APPS += ['tests.test_migrate']
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',

--- a/tests/test_migrate/tests.py
+++ b/tests/test_migrate/tests.py
@@ -1,15 +1,31 @@
-"""A writable test, not specifically important what is tested"""
+"""
+A writable test, not specifically important what is tested
+
+both databases are non-salesforce
+"""
+from django.conf import settings
 from django.test import TestCase
 
-from .models import Contact
+from salesforce.backend.test_helpers import default_is_sf
+from .models import Contact, User
 
 
 class CompatibilityTest(TestCase):
     databases = '__all__'
 
     def test_capitalized_id(self):
+        # prepare a Contact
         test_contact = Contact(last_name='Smith')
+        if not default_is_sf:
+            # If SALESFORCE_DB_ALIAS is not a Salesforce database then a user must be created
+            # and set as the owner, because DefaultedOnCreate works only on SFDC servers
+            test_user = User.objects.create(username='test', last_name='test', email='test@example.com')
+            test_contact.owner = test_user
         test_contact.save()
+
+        # test that the primary key 'Id' works
+        sf_pk = getattr(settings, 'SF_PK', 'id')
+        self.assertTrue(hasattr(test_contact, sf_pk))
         try:
             refreshed_contact = Contact.objects.get(pk=test_contact.pk)
             self.assertEqual(refreshed_contact.pk, test_contact.pk)

--- a/tests/test_mixin/models.py
+++ b/tests/test_mixin/models.py
@@ -52,11 +52,11 @@ class PersonAccount(SalesforceModel):
         abstract = True
 
 
-if getattr(settings, 'PERSON_ACCOUNT_ACTIVATED', False):
-    class Account(CommonAccount, PersonAccount):
+if not getattr(settings, 'PERSON_ACCOUNT_ACTIVATED', False):
+    class Account(CommonAccount, CoreAccount):
         pass
 else:
-    class Account(CommonAccount, CoreAccount):
+    class Account(CommonAccount, PersonAccount):  # type: ignore[no-redef] # noqa
         pass
 
 

--- a/tests/test_mixin/models.py
+++ b/tests/test_mixin/models.py
@@ -17,7 +17,7 @@ class DefaultMixin(SalesforceModel):
     """Common fields used in the most of SFDC models."""
     last_modified_date = models.DateTimeField(sf_read_only=models.READ_ONLY, auto_now=True)
     owner = models.ForeignKey(User, on_delete=models.DO_NOTHING,
-                              default=lambda: User(pk='DEFAULT'))  # db_column='OwnerId'
+                              default=models.DEFAULTED_ON_CREATE)  # db_column='OwnerId'
 
     class Meta:
         abstract = True

--- a/tests/test_mixin/settings.py
+++ b/tests/test_mixin/settings.py
@@ -1,6 +1,6 @@
 from salesforce.testrunner.settings import *  # NOQA pylint: disable=unused-wildcard-import,wildcard-import
 from salesforce.testrunner.settings import INSTALLED_APPS
 
-INSTALLED_APPS = tuple(x for x in INSTALLED_APPS if x != 'salesforce.testrunner.example')
-INSTALLED_APPS += ('tests.test_mixin',)
+INSTALLED_APPS = [x for x in INSTALLED_APPS if x != 'salesforce.testrunner.example']
+INSTALLED_APPS += ['tests.test_mixin']
 ROOT_URLCONF = None

--- a/tests/test_mixin/tests.py
+++ b/tests/test_mixin/tests.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from django.test import TestCase
 from tests.test_mixin.models import Account, Contact, Proxy2Contact
 from salesforce.backend.test_helpers import current_user, uid_version as uid

--- a/tests/test_mock/mocksf.py
+++ b/tests/test_mock/mocksf.py
@@ -40,6 +40,7 @@ Parameters
     json:  it is unused and will be probably deprecated.
            It can be replaced by "json.dumps(request_json)"
 """
+from typing import Optional
 from unittest import mock  # pylint:disable=unused-import  # NOQA
 import json as json_mod
 import re
@@ -151,7 +152,7 @@ class MockRequest(object):
     If the parameter 'request_type' is '*' then the request is not tested
     """
     # pylint:disable=too-few-public-methods,too-many-instance-attributes
-    default_type = None
+    default_type = None  # type: Optional[str]
 
     def __init__(self, method_url,  # pylint:disable=too-many-arguments
                  req=None, resp=None,
@@ -284,7 +285,7 @@ class MockTestCase(TestCase):
 
 class MockResponse(object):
     """Mock response for some unit tests offline"""
-    default_type = None
+    default_type = None  # type: Optional[str]
 
     def __init__(self, text, resp_content_type=None, status_code=200):
         self.text = text

--- a/tests/test_mock/mocksf.py
+++ b/tests/test_mock/mocksf.py
@@ -40,6 +40,7 @@ Parameters
     json:  it is unused and will be probably deprecated.
            It can be replaced by "json.dumps(request_json)"
 """
+from unittest import mock  # pylint:disable=unused-import  # NOQA
 import json as json_mod
 import re
 
@@ -52,11 +53,6 @@ import salesforce
 # from salesforce.dbapi import settings
 from salesforce.auth import MockAuth
 from salesforce.backend.test_helpers import sf_alias
-
-try:
-    from unittest import mock  # pylint:disable=unused-import
-except ImportError:
-    import mock  # NOQA
 
 APPLICATION_JSON = 'application/json;charset=UTF-8'
 

--- a/tests/test_mock/mocksf.py
+++ b/tests/test_mock/mocksf.py
@@ -40,19 +40,22 @@ Parameters
     json:  it is unused and will be probably deprecated.
            It can be replaced by "json.dumps(request_json)"
 """
-from typing import Optional
+from typing import Optional, Set, Union
 from unittest import mock  # pylint:disable=unused-import  # NOQA
 import json as json_mod
 import re
 
 from django.db import connections
-from django.test import TestCase
+from django.test import SimpleTestCase
 
 from django.conf import settings
 
 import salesforce
 # from salesforce.dbapi import settings
 from salesforce.auth import MockAuth
+from salesforce.dbapi import driver
+from salesforce.dbapi.exceptions import DatabaseError
+from salesforce.backend import DJANGO_22_PLUS
 from salesforce.backend.test_helpers import sf_alias
 
 APPLICATION_JSON = 'application/json;charset=UTF-8'
@@ -105,6 +108,8 @@ class MockRequestsSession(object):
                 output.append('"%s %s"' % (method, url))
                 if data:
                     output.append("req=%r" % data)
+                if 'json' in kwargs:
+                    output.append("request_json=%r" % kwargs['json'])
                 if response.text:
                     output.append("resp=%r" % response.text)
 
@@ -121,11 +126,12 @@ class MockRequestsSession(object):
                     output.append("response_type=%r" % response_type)
                 if response.status_code != 200:
                     output.append("status_code=%d" % response.status_code)
-                print("=== MOCK RECORD {testcase}\n{class_name}(\n    {params})\n===".format(
-                    class_name=request_class.__name__,
-                    testcase=self.testcase,
-                    params=',\n    '.join(output)
-                    ))
+                if self.verbosity > 0:
+                    print("=== MOCK RECORD {testcase}\n{class_name}(\n    {params})\n===".format(
+                        class_name=request_class.__name__,
+                        testcase=self.testcase,
+                        params=',\n    '.join(output)
+                        ))
             return response
         raise NotImplementedError("Not implemented SF_MOCK_MODE=%s" % mode)
 
@@ -143,6 +149,10 @@ class MockRequestsSession(object):
 
     def mount(self, prefix, adapter):
         pass
+
+    @property
+    def verbosity(self):
+        return getattr(settings, 'SF_MOCK_VERBOSITY', 1)
 
 
 class MockRequest(object):
@@ -224,15 +234,22 @@ class MockJsonRequest(MockRequest):
     default_type = APPLICATION_JSON
 
 
-class MockTestCase(TestCase):
+class MockTestCase(SimpleTestCase):
     """
     Test case that uses recorded requests/responses instead of network
     """
+    if DJANGO_22_PLUS:
+        databases = {'salesforce'}  # type: Union[Set[str], str]
+    else:
+        allow_database_queries = True
+
     def setUp(self):
         # pylint:disable=protected-access
         mode = getattr(settings, 'SF_MOCK_MODE', 'playback')
         super(MockTestCase, self).setUp()
         connection = connections[sf_alias]
+        if connection.vendor != 'salesforce':
+            raise DatabaseError("MockTestCase can run only on Salesforce databases")
         if not connection.connection:
             connection.connect()
         if mode != 'playback':
@@ -247,6 +264,8 @@ class MockTestCase(TestCase):
 
         self.save_api_ver = connection.api_ver
         connection.api_ver = getattr(self, 'api_ver', salesforce.API_VERSION)
+        # simulate a recent request (to not run a check for broken conection in the test)
+        driver.time_statistics.expiration = 1E10
 
     def tearDown(self):
         if hasattr(self, '_outcome'):  # Python 3.4+
@@ -270,6 +289,7 @@ class MockTestCase(TestCase):
         # connection._sf_session, connection._sf_auth = self.save_session_auth
         connection._sf_session = self.save_session_auth  # pylint:disable=protected-access
         connection.api_ver = self.save_api_ver
+        driver.time_statistics.expiration = driver.TimeStatistics().expiration
         super(MockTestCase, self).tearDown()
 
     def list2reason(self, exc_list):

--- a/tests/test_mock/test_mocksf.py
+++ b/tests/test_mock/test_mocksf.py
@@ -4,7 +4,6 @@ Test that MockTestCase works in all modes, including "record"
 """
 from django.db import connections
 from django.test.utils import override_settings
-from six import text_type
 
 from salesforce.backend.test_helpers import sf_alias
 from tests.test_mock.mocksf import mock, MockJsonRequest, MockTestCase
@@ -45,7 +44,7 @@ class TestMock(MockTestCase):
         cur.execute("SELECT Name FROM Contact LIMIT 1")
         row, = cur.fetchall()
         self.assertEqual(len(row), 1)
-        self.assertIsInstance(row[0], text_type)
+        self.assertIsInstance(row[0], str)
 
     @override_settings(SF_MOCK_MODE='playback')
     def test_response_parser(self):

--- a/tests/test_mock/test_mocksf.py
+++ b/tests/test_mock/test_mocksf.py
@@ -38,6 +38,7 @@ class TestMock(MockTestCase):
         connections[sf_alias].connection._sf_session.index += 1  # mock a consumed request
 
     @override_settings(SF_MOCK_MODE='record')
+    @override_settings(SF_MOCK_VERBOSITY=0)
     def test_mock_record(self):
         # test
         cur = connections[sf_alias].cursor()

--- a/tox.ini
+++ b/tox.ini
@@ -100,6 +100,7 @@ deps =
     git+https://github.com/hynekcer/django-salesforce-stubs.git@v1.5.0.1#django-stubs
 commands =
     mypy salesforce
+    mypy salesforce/dbapi --strict
     {toxinidir}/tests/mypy.sh
 
 # === lint configurations (not tests) ===

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ deps =
     git+https://github.com/hynekcer/beatbox-davisagli.git@7f628a789cba#egg=beatbox
     -rrequirements.txt
 commands =
-    {envpython} manage.py test salesforce
+    {envpython} manage.py test salesforce tests.test_mock
     {toxinidir}/tests/tests.sh
 setenv =
     # all bugs can be reported by the command `QUIET_KNOWN_BUGS=off tox`

--- a/tox.ini
+++ b/tox.ini
@@ -97,7 +97,12 @@ commands =
 # === lint configurations (not tests) ===
 [flake8]
 max-line-length = 119
-exclude=.git,.tox,.env,.eggs,build,migrations,models1*.py,packages_,tests/inspectdb/models.py,tests/tooling/models.py
+exclude =
+    .git,.tox,.env,.eggs,build,migrations,models1*.py,packages_
+    tests/inspectdb/models.py
+    tests/inspectdb/dependent_model/models_template.py
+    tests/tooling/models.py
+
 [pep8]
 max-line-length = 119
 exclude=.git,.tox,.env,.eggs,build,migrations,models1*.py,packages_,tests/inspectdb/models.py,tests/tooling/models.py

--- a/tox.ini
+++ b/tox.ini
@@ -14,16 +14,15 @@ envlist =
     py37-dj22
     py37-dj21
     py36-dj20
-    py27-dj111
+    py35-dj111
     py36-no_django
     debug_toolbar
 # Explicit combinations can be tested even though are not listed in ALL:
-# `tox -e py37-dj20,py37-djdev`
+# `tox -e py37-dj30,py37-djdev`
 # `tox -e docs`   # test documentation
 
 [testenv]
 basepython =
-    py27: python2.7
     py35: python3.5
     py36: python3.6
     py37: python3.7
@@ -36,14 +35,12 @@ deps =
     dj21: Django~=2.1.4
     dj22: Django~=2.2.0
     dj30: Django~=3.0.0
-    py27: mock
-    py27: typing
-    pylint: pylint
-    pylint: pylint-django
     djdev: https://github.com/django/django/archive/master.zip
     # local copy of django/origin master
     # wget https://github.com/django/django/archive/master.zip -O django-22-dev.zip
     # djdevlocal: django-22-dev.zip
+    pylint: pylint
+    pylint: pylint-django
     coverage
     # This Beatbox version works with Python 3 and 2.
     # Be hopeful, it will be soon in official repositories.

--- a/tox.ini
+++ b/tox.ini
@@ -98,7 +98,9 @@ basepython = python3
 deps =
     mypy>=0.770
     git+https://github.com/hynekcer/django-salesforce-stubs.git@v1.5.0.1#django-stubs
-commands = mypy salesforce
+commands =
+    mypy salesforce
+    {toxinidir}/tests/mypy.sh
 
 # === lint configurations (not tests) ===
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ basepython =
     py36: python3.6
     py37: python3.7
     py38: python3.8
+    py39: python3.9
     pypy: pypy
     pypy3: pypy3
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@
 minversion = 2.6
 envlist =
     docs_style
+    typing
     py38-dj30
     py37-dj22
     py37-dj21
@@ -90,6 +91,13 @@ deps =
 commands =
     flake8
     rstcheck README.rst CHANGELOG.rst
+
+[testenv:typing]
+basepython = python3
+deps =
+    mypy>=0.770
+    git+https://github.com/hynekcer/django-salesforce-stubs.git@v1.5.0.1#django-stubs
+commands = mypy salesforce
 
 # === lint configurations (not tests) ===
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -94,7 +94,8 @@ commands =
     rstcheck README.rst CHANGELOG.rst
 
 [testenv:typing]
-basepython = python3
+# any python >= 3.5.3
+basepython = python3.7
 deps =
     mypy>=0.770
     git+https://github.com/hynekcer/django-salesforce-stubs.git@v1.5.0.1#django-stubs


### PR DESCRIPTION
This replaces PR #252 (every commit of the new PR passed all tests)
Most of commits is about static typing of the project.

Changelog
--------------

* Remove: Support for Django 1.10
* Remove: Support for Python 2.7, 3.4
* Add: Support for Python 3.9 (alpha 5)
* Add: Preliminary support for Django 3.1-dev (development snaphot 2020-04-21)
* Fix: Fixed all hidden deprecation warnings. (related removed old versions)
* Fix: .annotate() method can use GROUP BY if Django >= 2.1
       example queryset.order_by().values('account_id').annotate(cnt=Count('id'))
* Fix: DefaultedOnCreate() and DEFAULTED_ON_CREATE is now transparent for
       other code. It has a surrogate normal value and it is never saved #213
* Add: Warning if a value DEFAULTED_ON_CREATE is tried to be saved again without
       refreshing the real value.
* Fix: Support for Django Debug Toolbar - including EXPLAIN commend
* Fix: Consistent output of inspectdb with db_column on every field.
       The old behavior with ``custom=`` parameter and minimalistic db_column
       can be turn on by ``--concise-db-column`` option. #250
* Fix: Export attributes "verbose_name", "help_text" and "default=DEFAULTED_ON_CREATE"
       also for ForeignKey by inspectdb.
* Fix: Not to export DEFAULTED_ON_CREATE excessively for not createable fields.
* Fix: Error handling in bulk delete()
* Fix: SomeModel.objects.all().delete()
* Fix: Wildcard search with characters "_" and "%". #254
* Fix: Accept a manually added AutoField in models.
* Fix: Close correctly all SSL sockets before dropped. (minor)
* Fix: Lazy test helper fixed for Python >= 3.8 (lazy: exception can be tested later
       then the fail was detected. It uses two tracebacks. 
       e.g. ``with lazy_assert_n_requests(n)``: check that the optimal number
       of requests was used if everything critical was OK and show the first 
       suboptimal command-line.)
* Add: Bulk update limited to 200 objects: bulk_update_small()
* Add: Static typing by [Mypy](http://www.mypy-lang.org/). Can validate user code that correspondd to the user data model.
        with SalesforceModel (requires also installed [django-salesforce-stubs](https://github.com/hynekcer/django-salesforce-stubs) 1.5.0.1)
* Update: Salesforce 48.0 Spring '20 (no fix)
* Add: Raw cursor with fields dict: ``connection.cursor(name='dict')``
* Add: Internal module mocksf is used in tests/debugging for record or replay of
       raw Salesforce requests/responses.

Static typing hints: It is important that the user code attributes and types can be checked against the user models, similarly like django-stubs allows it for Django. An internal code that depends on Django is mostly not annotated because Django internals are also not annotated. The module ``salesforce.dbapi`` is strictly annotated and passed a ``--strict`` check.