### PR TITLE
Fix issue-253 and pass sf parameters to querysets

### DIFF
--- a/salesforce/backend/manager.py
+++ b/salesforce/backend/manager.py
@@ -53,8 +53,20 @@ class SalesforceManager(manager.Manager, Generic[_T]):
     #                                            params=params, using=self.db)
     #     return super(SalesforceManager, self).raw(raw_query, params=params, translations=translations)
 
+    # methods of SalesforceQuerySet on a SalesfroceManager
+
     def query_all(self) -> 'query.SalesforceQuerySet[_T]':  # type: ignore[override] # noqa
         qs = self.get_queryset()
         assert isinstance(qs, query.SalesforceQuerySet)
-        ret = qs.query_all()  # type: query.SalesforceQuerySet[_T]
+        ret = qs.query_all()
         return ret
+
+    def sf(self,
+           query_all: Optional[bool] = None,
+           ) -> 'query.SalesforceQuerySet[_T]':
+        # not dry, but explicit due to preferring type check of user code
+        qs = self.get_queryset()
+        assert isinstance(qs, query.SalesforceQuerySet)
+        return qs.sf(
+            query_all=query_all,
+        )

--- a/salesforce/backend/manager.py
+++ b/salesforce/backend/manager.py
@@ -20,7 +20,7 @@ from django.db.models import manager, Model
 from django.db.models.query import QuerySet
 
 from salesforce import router
-from salesforce.backend import query, models_sql_query, compiler, DJANGO_20_PLUS
+from salesforce.backend import query, DJANGO_20_PLUS
 
 _T = TypeVar("_T", bound=Model, covariant=True)
 
@@ -43,9 +43,7 @@ class SalesforceManager(manager.Manager, Generic[_T]):
         is_extended_model = getattr(self.model, '_salesforce_object', '') == 'extended'
         assert self.model is not None
         if router.is_sf_database(self.db) or alias_is_sf or is_extended_model:
-            q = models_sql_query.SalesforceQuery(self.model, where=compiler.SalesforceWhereNode)
-            ret = query.SalesforceQuerySet(self.model, query=q, using=self.db)  # type: query.SalesforceQuerySet[_T]
-            return ret
+            return query.SalesforceQuerySet(self.model, using=self.db)
         return super(SalesforceManager, self).get_queryset()
 
     # def raw(self, raw_query, params=None, translations=None):

--- a/salesforce/backend/manager.py
+++ b/salesforce/backend/manager.py
@@ -64,6 +64,7 @@ class SalesforceManager(manager.Manager, Generic[_T]):
     def sf(self,
            query_all: Optional[bool] = None,
            all_or_none: Optional[bool] = None,
+           edge_updates: Optional[bool] = None,
            ) -> 'query.SalesforceQuerySet[_T]':
         # not dry, but explicit due to preferring type check of user code
         qs = self.get_queryset()
@@ -71,4 +72,5 @@ class SalesforceManager(manager.Manager, Generic[_T]):
         return qs.sf(
             query_all=query_all,
             all_or_none=all_or_none,
+            edge_updates=edge_updates,
         )

--- a/salesforce/backend/manager.py
+++ b/salesforce/backend/manager.py
@@ -63,10 +63,12 @@ class SalesforceManager(manager.Manager, Generic[_T]):
 
     def sf(self,
            query_all: Optional[bool] = None,
+           all_or_none: Optional[bool] = None,
            ) -> 'query.SalesforceQuerySet[_T]':
         # not dry, but explicit due to preferring type check of user code
         qs = self.get_queryset()
         assert isinstance(qs, query.SalesforceQuerySet)
         return qs.sf(
             query_all=query_all,
+            all_or_none=all_or_none,
         )

--- a/salesforce/backend/models_sql_query.py
+++ b/salesforce/backend/models_sql_query.py
@@ -45,6 +45,7 @@ class SfParams:  # like an immutable DataClass: clone when updating
     def __init__(self):
         self.query_all = False
         self.all_or_none = None  # type: Optional[bool]
+        self.edge_updates = False
 
 
 class SalesforceQuery(Query, Generic[_T]):
@@ -84,6 +85,7 @@ class SalesforceQuery(Query, Generic[_T]):
     def sf(self,
            query_all: Optional[bool] = None,
            all_or_none: Optional[bool] = None,
+           edge_updates: Optional[bool] = None,
            ) -> 'SalesforceQuery[_T]':
         """
         Set additional parameters for a queryset
@@ -99,6 +101,11 @@ class SalesforceQuery(Query, Generic[_T]):
                 Default: No following block after an error is tried, but also no rollback is done
                     in a block with some errors. (This neutral behavior can not be set back after
                     True or False.)
+
+            `edge_updates`: methods update() and delete() on querysets with related tables
+                could be unsafe if the queryset is not checked. It safe to rewrite it to two
+                nested querysets or if it is correct then if can be allowed by `edge_updates`.
+                default is False.
         """
         clone = self.clone()
         clone.sf_params = copy.copy(self.sf_params)
@@ -106,6 +113,8 @@ class SalesforceQuery(Query, Generic[_T]):
             clone.sf_params.query_all = query_all
         if all_or_none is not None:
             clone.sf_params.all_or_none = all_or_none
+        if edge_updates is not None:
+            clone.sf_params.edge_updates = edge_updates
         return clone
 
     def has_results(self, using: Optional[str]) -> bool:

--- a/salesforce/backend/models_sql_query.py
+++ b/salesforce/backend/models_sql_query.py
@@ -44,7 +44,7 @@ class SalesforceQuery(Query, Generic[_T]):
     """
     Override aggregates.
     """
-    def __init__(self, model: Type[_T], *args, **kwargs) -> None:
+    def __init__(self, model: Optional[Type[_T]], *args, **kwargs) -> None:
         super(SalesforceQuery, self).__init__(model, *args, **kwargs)
         self.is_query_all = False
         self.max_depth = 1

--- a/salesforce/backend/query.py
+++ b/salesforce/backend/query.py
@@ -91,6 +91,7 @@ class SalesforceQuerySet(models_query.QuerySet, Generic[_T]):
     def sf(self,
            query_all: Optional[bool] = None,
            all_or_none: Optional[bool] = None,
+           edge_updates: Optional[bool] = None,
            ) -> 'SalesforceQuerySet[_T]':
         """Set additional parameters for queryset methods with Salesforce.
 
@@ -107,6 +108,7 @@ class SalesforceQuerySet(models_query.QuerySet, Generic[_T]):
         clone.query = clone.query.sf(
             query_all=query_all,
             all_or_none=all_or_none,
+            edge_updates=edge_updates,
         )
         return clone
 

--- a/salesforce/backend/utils.py
+++ b/salesforce/backend/utils.py
@@ -335,7 +335,9 @@ class CursorWrapper(object):
                 assert not child.bilateral_transforms
                 if isinstance(pks, (tuple, list)):
                     return pks
-                assert isinstance(pks, Query) and type(pks).__name__ == 'SalesforceQuery', (
+                # 'sf_params' are also in 'pks' only in Django >= 2.0, therefore check query.sf_params
+                assert (isinstance(pks, Query) and type(pks).__name__ == 'SalesforceQuery' or
+                        query.sf_params.edge_updates), (
                     "Too complicated queryset.update(). Rewrite it by two querysets. "
                     "See docs wiki/error-messages")
                 # # alternative solution:

--- a/salesforce/backend/utils.py
+++ b/salesforce/backend/utils.py
@@ -276,8 +276,8 @@ class CursorWrapper(object):
     def execute_select(self, soql: str, args) -> None:
         if soql != MIGRATIONS_QUERY_TO_BE_IGNORED:
             # normal query
-            is_query_all = self.query and self.query.is_query_all
-            self.cursor.execute(soql, args, query_all=is_query_all)
+            query_all = self.query and self.query.sf_params.query_all
+            self.cursor.execute(soql, args, query_all=query_all)
         else:
             # Nothing queried about django_migrations to SFDC and immediately responded that
             # nothing about migration status is recorded in SFDC.

--- a/salesforce/backend/utils.py
+++ b/salesforce/backend/utils.py
@@ -305,7 +305,8 @@ class CursorWrapper(object):
         if self.db.connection.composite_type == 'sobject-collections':
             # SObject Collections
             records = [merge_dict(x, type_=table) for x in post_data]
-            ret = self.db.connection.sobject_collections_request('POST', records)
+            all_or_none = query.sf_params.all_or_none
+            ret = self.db.connection.sobject_collections_request('POST', records, all_or_none=all_or_none)
             self.lastrowid = ret
             self.rowcount = len(ret)
             return
@@ -368,7 +369,8 @@ class CursorWrapper(object):
         if self.db.connection.composite_type == 'sobject-collections':
             # SObject Collections
             records = [merge_dict(post_data, id=pk, type_=table) for pk in pks]
-            ret = self.db.connection.sobject_collections_request('PATCH', records)
+            all_or_none = query.sf_params.all_or_none
+            ret = self.db.connection.sobject_collections_request('PATCH', records, all_or_none=all_or_none)
             self.lastrowid = ret
             self.rowcount = len(ret)
             return
@@ -394,7 +396,8 @@ class CursorWrapper(object):
         if self.db.connection.composite_type == 'sobject-collections':
             # SObject Collections
             records = pks
-            ret = self.db.connection.sobject_collections_request('DELETE', records)
+            all_or_none = None  # sf_params not supported by DeleteQuery
+            ret = self.db.connection.sobject_collections_request('DELETE', records, all_or_none=all_or_none)
             self.lastrowid = ret
             self.rowcount = len(ret)
             return

--- a/salesforce/models.py
+++ b/salesforce/models.py
@@ -107,11 +107,13 @@ else:
         # pylint:disable=invalid-name
         _salesforce_object = 'standard'
 
+        # if both managers are spedified they must be different objects in Python <= 3.5.x
+        base_manager = manager.SalesforceManager()  # type: manager.SalesforceManager[_T]
         objects = manager.SalesforceManager()  # type: manager.SalesforceManager[_T]
 
         class Meta:
             abstract = True
-            base_manager_name = 'objects'
+            base_manager_name = 'base_manager'
             if not DJANGO_20_PLUS:
                 manager_inheritance_from_future = True
 

--- a/salesforce/tests/test_unit.py
+++ b/salesforce/tests/test_unit.py
@@ -165,3 +165,16 @@ class TestTopologyCompiler(TestCase):
             ('A', 'C', (('Id', 'AId'),), 'C'),
             ('C', 'B', (('BId', 'Id'),), 'B')]
         self.assertTopo(alias_map_items, {'C': 'C', 'A': 'C.A', 'B': 'C.B'})
+
+
+class SfParamsTest(TestCase):
+    def test_params_handover_and_isolation(self):
+        """Test that sp_params are propagated to the rest of the queryset chain
+        but isolated from the previous part.
+        """
+        qs_1 = Contact.objects.all()
+        qs_2 = qs_1.sf(query_all=True)
+        qs_3 = qs_2.filter(first_name__gt='A')
+        # a valua is propagated to the next level, but not to the previous
+        self.assertTrue(qs_3.query.sf_params.query_all)
+        self.assertFalse(qs_1.query.sf_params.query_all)

--- a/tests/test_default_db/test.sh
+++ b/tests/test_default_db/test.sh
@@ -2,4 +2,5 @@
 rm -f tests/test_default_db/migrations/000*
 python manage.py makemigrations --settings=tests.test_default_db.settings test_default_db
 python manage.py test --settings=tests.test_default_db.settings tests.test_default_db && \
-    rm tests/test_default_db/migrations/0001_initial.py*
+    rm tests/test_default_db/migrations/0001_initial.py && \
+    rm tests/test_default_db/migrations/__init__.py

--- a/tests/test_managers/models.py
+++ b/tests/test_managers/models.py
@@ -1,0 +1,29 @@
+"""Backward compatible behaviour with primary key 'Id' and upper-case field names"""
+
+from salesforce import models
+from salesforce.models import SalesforceModel
+from salesforce.backend.manager import SalesforceManager
+from salesforce.backend.query import SalesforceQuerySet
+
+
+class ContactQuerySet(SalesforceQuerySet):
+    def people(self):
+        return self.filter(account__name__gt='A')
+
+
+class FilteredManager(SalesforceManager):
+    def get_queryset(self):
+        return ContactQuerySet(self.model, using=self._db).people()
+
+    def people(self):
+        return self.get_queryset().people()
+
+
+class Account(SalesforceModel):
+    name = models.CharField(max_length=80)
+
+
+class Contact(SalesforceModel):
+    last_name = models.CharField(max_length=80)
+    account = models.ForeignKey(Account, models.DO_NOTHING)
+    objects = FilteredManager()

--- a/tests/test_managers/settings.py
+++ b/tests/test_managers/settings.py
@@ -1,0 +1,9 @@
+from django.utils.crypto import get_random_string
+from salesforce.testrunner.local_settings import DATABASES  # noqa # necessary for setup
+
+SECRET_KEY = get_random_string()
+
+INSTALLED_APPS = ['tests.test_managers']
+DATABASE_ROUTERS = ["salesforce.router.ModelRouter"]
+SF_LAZY_CONNECT = True
+USE_TZ = True

--- a/tests/test_managers/test.sh
+++ b/tests/test_managers/test.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+python manage.py test --settings=tests.test_managers.settings tests.test_managers

--- a/tests/test_managers/tests.py
+++ b/tests/test_managers/tests.py
@@ -1,0 +1,36 @@
+"""Test djangoBackward compatible behaviour with primary key 'Id'."""
+from django.test import TestCase
+
+from .models import Account, Contact
+from salesforce.backend.test_helpers import LazyTestMixin
+
+
+class CompatibilityTest(TestCase, LazyTestMixin):
+    databases = {'salesforce'}
+
+    def test_alternate_default_manager(self) -> None:
+        """Test an alternate default manager with a queryset"""
+        test_acc = Account.objects.create(name='Aa')
+        test_cnt = Contact.objects.create(last_name='B', account=test_acc)
+        try:
+            # test that only one request is used for .save()
+            with self.lazy_assert_n_requests(1):
+                test_cnt.save()
+
+            # test again that only one request is used for .save() for a combined queryset
+            wrk = Contact.objects.filter(last_name='B')
+            tmp = wrk[0]
+            tmp.last_name = 'C'
+            with self.lazy_assert_n_requests(1):
+                tmp.save()
+
+            # check that the default queryset is not empty
+            _ = Contact.objects.all()[0]
+
+            # with self.lazy_assert_n_requests(2):
+            #     Contact.objects.update(last_name='sf_test')
+
+            self.lazy_check()
+        finally:
+            test_cnt.delete()
+            test_acc.delete()

--- a/tests/test_managers/tests.py
+++ b/tests/test_managers/tests.py
@@ -27,8 +27,8 @@ class CompatibilityTest(TestCase, LazyTestMixin):
             # check that the default queryset is not empty
             _ = Contact.objects.all()[0]
 
-            # with self.lazy_assert_n_requests(2):
-            #     Contact.objects.update(last_name='sf_test')
+            with self.lazy_assert_n_requests(2):
+                Contact.objects.sf(edge_updates=True).update(last_name='sf_test')
 
             self.lazy_check()
         finally:


### PR DESCRIPTION
Four commits are directly related to #253 (custom queryset on the default manager) and an important problem is solved, how to pass additional parameters to Salesforce methods

* Refactoring for clearer responsibility of objects
* Test for 253
* Added independent base manager
* Added a parameter `edge_updates` to enable updates on querysets that could be potentially unsafe and should be checked before use in production. The parameter `edge_updates` should be used only if the queryset is verified or similarly complex querysets are known compiled correctly. 

Additional parameters can be passed by a `sf(...)` method.
Example:
``` python
    SomeModel.objects.sf(edge_updates=True).filter(related_model__some_field=value).update(...)
```
That parameters are ignored if the database backend is not salesforce. It is currently recommended that the sf() method is used at the beginning of methods chain, if the code should work also for non Salesforce databases.

* Similarly a parameter `.sf(all_or_none=True)` can be added before update() so specify a small transaction by 200 objects

Most of commits passed all tests, only the commit 526bc2f (added test project) fails because it is a test before a fix.