### PR TITLE
Authenticate by Refresh Token (replacement of password)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,8 +34,8 @@ Install, configure a Salesforce connection, create a Salesforce model and run.
 
     'salesforce': {
         'ENGINE': 'salesforce.backend',
-        'CONSUMER_KEY': '',                   # client_id
-        'CONSUMER_SECRET': '',                # client_secret
+        'CONSUMER_KEY': '',                # 'client_id'   in OAuth2 terminology
+        'CONSUMER_SECRET': '',             # 'client_secret'
         'USER': '',
         'PASSWORD': '',
         'HOST': 'https://test.salesforce.com',

--- a/README.rst
+++ b/README.rst
@@ -34,8 +34,8 @@ Install, configure a Salesforce connection, create a Salesforce model and run.
 
     'salesforce': {
         'ENGINE': 'salesforce.backend',
-        'CONSUMER_KEY': '',
-        'CONSUMER_SECRET': '',
+        'CONSUMER_KEY': '',                   # client_id
+        'CONSUMER_SECRET': '',                # client_secret
         'USER': '',
         'PASSWORD': '',
         'HOST': 'https://test.salesforce.com',
@@ -53,9 +53,9 @@ Install, configure a Salesforce connection, create a Salesforce model and run.
      - Click "Enable OAuth Settings" in API, then select "Access and manage
        your data (api)" from available OAuth Scopes.
      - Other red marked fields must be filled, but are not relevant for Django
-       with password authentication. (For example a "Callback URL" can be an
-       URL that doesn't exist, but that is under your control, for the case that
-       you accidentally activate other OAuth mode later.)
+       with password authentication. ("Callback URL" should be a safe URL
+       that maybe doesn't exist, but is under your control and doesn't redirect,
+       for the case that you accidentally activate other OAuth mode later.)
    * ``USER`` is the username used to connect.
    * ``PASSWORD`` is a concatenation of the user's password and security token.
      Security token can be set by My Settings / Personal / Reset My Security Token

--- a/salesforce/dbapi/driver.py
+++ b/salesforce/dbapi/driver.py
@@ -186,7 +186,7 @@ class RawConnection:
         """Authenticate and get the name of assigned SFDC data server"""
         with connect_lock:
             if self._sf_session is None:
-                auth_data = self.sf_auth.authenticate()
+                auth_data = self.sf_auth.authenticate_and_cache()
                 sf_instance_url = auth_data.get('instance_url')
                 sf_session = SfSession()
                 sf_session.auth = self.sf_auth


### PR DESCRIPTION
The last authenticator the completed everything on the refactored modular `auth.py` is the authentication by refresh token, class `salesforce.auth.RefreshTokenAuth`. It is briefly desribed in Wiki [Refresh Token Auth](https://github.com/django-salesforce/django-salesforce/wiki/Experimental-Features#refresh-token-auth). It allows to get a refresh token interactively by web browser by opening one link from console and copying another final link after authorization back to console. The refresh token written on the console should be saved to settings to remain authenticated also after restart.

I prefer to commit it not before v1.1