### PR TITLE
Version 3.1 compatible with Django 3.1 final

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ install:
 script:
   - rstcheck README.rst
   - echo -e "SF_PK = 'Id'" > salesforce/testrunner/local_settings.py
-  - tox -r -e py36-dj30,py36-dj22,py35-dj111,debug_toolbar
+  - tox -r -e py36-dj31,py36-dj30,py36-dj22,py35-dj111,debug_toolbar

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,8 +14,19 @@ Some items here can be marked as "internal": not ready enough or
 experimental.
 
 
-[1.1] 2009-04-09
+[3.1] Unpublished
 -----------------
+* Fix: Enable support for Django 3.1 final.
+* Change: Package versions will be synchronized with Django "release version" from now on.
+
+
+[1.1] 2020-07-09
+----------------
+* Add: Optional Refresh Token Authentication by ``RefreshTokenAuth`` with
+  cryptographic code_challenge / code_verifier.
+* Add: Tag `[django-salesforce]
+  <https://stackoverflow.com/questions/tagged/django-salesforce>`_
+  for questions on Stackoverflow.com.
 * Fix: Allow SOQL query up to 100000 characters, fixed #164 
 * Add: Support for custom authentication modules configurable by
   ``settings.DATABASES['salesforce']['AUTH']``

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ django-salesforce
 .. image:: https://img.shields.io/badge/python-3.5%20%7C%203.6%20%7C%203.7%20%7C%203.8-blue
    :target: https://www.python.org/
 
-.. image:: https://img.shields.io/badge/Django-1.11%2C%202.0%2C%202.1%2C%202.2%2C%203.0-blue.svg
+.. image:: https://img.shields.io/badge/Django-1.11%2C%202.0%2C%202.1%2C%202.2%2C%203.0%2C%203.1-blue.svg
    :target: https://www.djangoproject.com/
 
 This library allows you to load, edit and query the objects in any Salesforce instance
@@ -19,8 +19,8 @@ for most uses. It works by integrating with the Django ORM, allowing access to
 the objects in your SFDC instance (Salesforce .com) as if they were in a
 traditional database.
 
-Python 3.5.3 to 3.8, Django 1.11, 2.0 to 2.2 and 3.0.
-(Tested also with Python 3.9.0a5)
+Python 3.5.3 to 3.8, Django 1.11 to 3.1.
+(Tested also with Python 3.9.0b4)
 
 
 Quick Start
@@ -290,5 +290,3 @@ The most important:
 
 -  v0.5: The name of primary key is currently ``'id'``. The backward compatible
    behavior for code created before v0.5 can be reached by settings ``SF_PK='Id'``.
-
-

--- a/salesforce/__init__.py
+++ b/salesforce/__init__.py
@@ -16,7 +16,7 @@ from salesforce.dbapi.exceptions import (  # NOQA pylint:disable=unused-import,u
     IntegrityError as IntegrityError, DatabaseError as DatabaseError, SalesforceError as SalesforceError,
 )
 
-__version__ = "1.1"
+__version__ = "3.1"
 
 log = logging.getLogger(__name__)
 

--- a/salesforce/__init__.py
+++ b/salesforce/__init__.py
@@ -22,5 +22,4 @@ log = logging.getLogger(__name__)
 
 # Default version of Force.com API.
 # It can be customized by settings.DATABASES['salesforce']['API_VERSION']
-# API_VERSION = '49.0'  # Summer '20
-API_VERSION = '48.0'  # Spring '20
+API_VERSION = '49.0'  # Summer '20

--- a/salesforce/backend/__init__.py
+++ b/salesforce/backend/__init__.py
@@ -39,8 +39,8 @@ DJANGO_22_PLUS = django.VERSION[:2] >= (2, 2)
 DJANGO_30_PLUS = django.VERSION[:2] >= (3, 0)
 DJANGO_31_PLUS = django.VERSION[:2] >= (3, 1)  # still only a development version exists
 is_dev_version = django.VERSION[3:] and re.match('(alpha|beta|rc)', django.VERSION[3])
-if django.VERSION[:2] < (1, 11) or django.VERSION[:2] > (3, 0) and not is_dev_version:
-    raise ImportError("Django version between 1.11 and 3.0 is required "
+if django.VERSION[:2] < (1, 11) or django.VERSION[:2] > (3, 1) and not is_dev_version:
+    raise ImportError("Django version between 1.11 and 3.1 is required "
                       "for this django-salesforce.")
     # Usually three or more blocking issues can be expected by every
     # new major Django version. Strict check before support is better.

--- a/tests/test_mock/mocksf.py
+++ b/tests/test_mock/mocksf.py
@@ -222,7 +222,7 @@ class MockRequest(object):
             testcase.assertEqual(request_type.split(';')[0], self.request_type.split(';')[0], msg=msg)
         kwargs.pop('timeout', None)
         assert kwargs.pop('verify', True) is True  # TLS verify must not be False
-        if 'json'in kwargs and kwargs['json'] is None:
+        if 'json' in kwargs and kwargs['json'] is None:
             del kwargs['json']
         if 'headers' in kwargs and not kwargs['headers']:
             del kwargs['headers']

--- a/tests/tooling/slow_test.py
+++ b/tests/tooling/slow_test.py
@@ -104,6 +104,7 @@ def run():
         'CustomApplication', 'CustomField', 'CustomTab', 'FlexiPage', 'GlobalValueSet',
         'Layout', 'QuickActionDefinition', 'RemoteProxy', 'ValidationRule',
         'WorkflowFieldUpdate', 'WorkflowRule',
+        'QuickActionListItem',
     }
 
     #  FIELD_INTEGRITY_EXCEPTION

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ minversion = 2.6
 envlist =
     docs_style
     typing
+    py39-dj31
     py38-dj30
     py37-dj22
     py37-dj21
@@ -37,6 +38,7 @@ deps =
     dj21: Django~=2.1.4
     dj22: Django~=2.2.0
     dj30: Django~=3.0.0
+    dj31: Django~=3.1.0
     djdev: https://github.com/django/django/archive/master.zip
     # local copy of django/origin master
     # wget https://github.com/django/django/archive/master.zip -O django-22-dev.zip


### PR DESCRIPTION
We must release a new version because `salesforce/backend/__init__.py ` supported only Django 3.1 development releases, bun not the 3.1 final. A simple command "pip install django django-salesforce" would not work
It is my mistake that I thought first about some new code for August release or the support should have been added already to the late 1.1.

It is strange that we must release a new version, we have no new code except the fixed version check and we wanted to synchronize the version number in August with 3.1.

Even the unofficial [Refresh Token Authentication](https://github.com/django-salesforce/django-salesforce/wiki/Experimental-Features#refresh-token-auth) is in our v1.1

Nevertheless, I propose to publish 3.1 (or you can rewrite the last commit and CHANGELOG)