### PR TITLE
Fix275

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -221,6 +221,12 @@ Advanced usage
    Consequently, the setting ``managed = True`` is related only to an alternate
    non SFDC database configured by ``SALESFORCE_DB_ALIAS``.)
 
+   There is probably no reason to collect old migrations of an application
+   that uses only SalesforceModel and all data are stored only in Salesforce.
+   Such old migrations can be easily deleted a new initial migration can be
+   created again if it is necessary for offline tests and that migrations directory
+   seems big or obsoleted.
+
 -  **Exceptions** - Custom exceptions instead of standard Django database
    exceptions are raised by Django-Salesforce to get more useful information.
    General exceptions are ``SalesforceError`` or a more general custom
@@ -271,6 +277,11 @@ Backwards-incompatible changes
 ------------------------------
 
 The most important:
+
+-  v1.0: The object ``salesforce.backend.operations.DefaultedOnCreate`` in an incidental
+   old migration should be rewritten to new ``salesforce.fields.DefaultedOnCreate``, but
+   old migrations are unnecessary usually.
+
 -  v0.9: This is the last version that suports Django 1.10 and Python 2.7 and 3.4
 
 -  v0.8: The default Meta option if now ``managed = True``, which is an important

--- a/salesforce/__init__.py
+++ b/salesforce/__init__.py
@@ -23,3 +23,4 @@ log = logging.getLogger(__name__)
 # Default version of Force.com API.
 # It can be customized by settings.DATABASES['salesforce']['API_VERSION']
 API_VERSION = '49.0'  # Summer '20
+# API_VERSION = '50.0'  # Winter '21

--- a/salesforce/backend/operations.py
+++ b/salesforce/backend/operations.py
@@ -15,7 +15,6 @@ import django.db.backends.utils
 from django.db.backends.base.operations import BaseDatabaseOperations
 from salesforce.backend import DJANGO_30_PLUS
 from salesforce.dbapi.exceptions import SalesforceWarning
-from salesforce.defaults import DefaultedOnCreate, DEFAULTED_ON_CREATE  # noqa # for backward compatibility migrations
 
 BULK_BATCH_SIZE = 200
 
@@ -132,3 +131,11 @@ class DatabaseOperations(BaseDatabaseOperations):
         # A wildcard search is better than a search of '\\%' or '\\_', see #254
         return str(x)
         # return str(x).replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
+
+
+def DefaultedOnCreate(*args, **kwargs):
+    import salesforce.defaults
+    warnings.warn("Deprecated: the object DefaultedOnCreate should be imported from "
+                  "salesforce.fields or salesforce.defaults or salesforce.models, "
+                  "but not from salesforce.backend.operations")
+    return salesforce.defaults(*args, **kwargs)

--- a/salesforce/defaults.py
+++ b/salesforce/defaults.py
@@ -1,9 +1,9 @@
 import datetime
 import decimal
 from pytz import utc
-from typing import Any, Callable, Dict, Optional, overload, Tuple, Type
+from typing import Any, Callable, Dict, Optional, overload, Tuple, Type, TYPE_CHECKING
 # from django.utils.deconstruct import deconstructible
-import salesforce.models
+import salesforce
 
 
 # --- DefaultedOnCreate ---
@@ -207,7 +207,10 @@ def DefaultedOnCreate(value: Any = None, internal_type: Optional[str] = None) ->
         klass = field_type_map[internal_type]
         return klass(klass.default)
     elif value is not None:
-        if isinstance(value, type) and issubclass(value, salesforce.models.Model):
+        if isinstance(value, type) and hasattr(value, '_salesforce_object'):
+            if TYPE_CHECKING:
+                import salesforce.models
+                assert issubclass(value, salesforce.models.Model)
             return foreign_key_factory_default(value)
         if callable(value):
             return CallableDefault(value)

--- a/salesforce/fields.py
+++ b/salesforce/fields.py
@@ -211,8 +211,9 @@ class DecimalField(SfField, models.DecimalField):
                 ret = Decimal(int(ret))
         return ret
 
-    # parameter "context" is for Django <= 1.11 (the same is in more classes here)
-    def from_db_value(self, value, expression, connection, context=None):
+    # a positional parameter "context" was in Django <= 1.11
+    # replaced by *args here to preven deprecation warning in Django 2.x
+    def from_db_value(self, value, expression, connection, *args):
         # pylint:disable=unused-argument
         # TODO refactor and move to the driver like in other backends
         if isinstance(value, float):
@@ -245,7 +246,9 @@ class DateTimeField(SfField, models.DateTimeField):
 class DateField(SfField, models.DateField):
     """DateField with sf_read_only attribute for Salesforce."""
 
-    def from_db_value(self, value, expression, connection, context=None):
+    # a positional parameter "context" was in Django <= 1.11
+    # replaced by *args here to preven deprecation warning in Django 2.x
+    def from_db_value(self, value, expression, connection, *args):
         # pylint:disable=unused-argument
         return self.to_python(value)
 
@@ -253,7 +256,9 @@ class DateField(SfField, models.DateField):
 class TimeField(SfField, models.TimeField):
     """TimeField with sf_read_only attribute for Salesforce."""
 
-    def from_db_value(self, value, expression, connection, context=None):
+    # a positional parameter "context" was in Django <= 1.11
+    # replaced by *args here to preven deprecation warning in Django 2.x
+    def from_db_value(self, value, expression, connection, *args):
         # pylint:disable=unused-argument
         return self.to_python(value)
 

--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -7,6 +7,8 @@ from typing import Dict
 import os
 import re
 import unittest
+from salesforce.backend import DJANGO_30_PLUS
+from salesforce.backend.test_helpers import expectedFailureIf
 
 
 def relative_path(path: str) -> str:
@@ -83,6 +85,11 @@ class ExportedModelTest(unittest.TestCase):
         self.assertRegex(line, r'#.* Master Detail Relationship \*')
         line = self.match_line('    created_by = ', classes_texts['Opportunity'])
         self.assertNotIn('Master Detail Relationship', line)
+
+    @expectedFailureIf(not DJANGO_30_PLUS)
+    def test_ont_to_one_field_introspection(self) -> None:
+        """Test that OneToOneField is correctly introspected"""
+        self.assertTrue(any('= models.OneToOneField(' in text for text in classes_texts.values()))
 
 
 classes_texts = get_classes_texts()

--- a/tests/tooling/slow_test.py
+++ b/tests/tooling/slow_test.py
@@ -75,6 +75,8 @@ def run():
         'ObjectSearchSetting', 'OpportunityInsightsSettings',
         'OpportunityListFieldsLabelMapping', 'OpportunityScoreSettings',
         'OrderManagementSettings', 'StandardAction', 'StandardValueSet',
+        # in API 50.0 Winter'20
+        'InventorySettings', 'SecuritySettings',
     }
     problematic_write = {
         # any SalesforceError
@@ -98,6 +100,10 @@ def run():
         'SurveySettings', 'SystemNotificationSettings', 'Territory2Settings',
         'TrialOrgSettings', 'User', 'UserEngagementSettings', 'UserInterfaceSettings',
         'UserManagementSettings', 'WebToXSettings', 'WorkDotComSettings',
+
+        # in API 50.0 Winter'20
+        'ExternalServicesSettings', 'RecommendationBuilderSettings',
+
         # ExpirationDate must be in the future.
         'TraceFlag',
         # silently not updated
@@ -147,11 +153,11 @@ def run():
                     obj.save(force_update=True)
                 except SalesforceError as exc:
                     new_problematic.append(db_table)
-                    stderr.write("\n************** SalesforceError %s %s\n" % (db_table, exc))
+                    stderr.write("\n************** write SalesforceError %s %s\n" % (db_table, exc))
                     n_write_errors += 1
                 except (TypeError, NotImplementedError) as exc:
                     new_problematic.append(db_table)
-                    stderr.write("\n************** %s %s %s\n" % (exc.__class__.__name__, db_table, exc))
+                    stderr.write("\n************** write %s %s %s\n" % (exc.__class__.__name__, db_table, exc))
                     n_write_errors += 1
                 else:
                     # object 'Topic' doesn't have the attribute 'last_modified_date'


### PR DESCRIPTION
Fixed a cyclic import ImportError caused by the previous commit. (If `salesforce.defaults` was imported before `salesforce.models` than the import failed. This problem was even more probable than the original issue #275.)
The old migrations will work now again, but with a deprecation warning. A documentation added about it.

Other commits in this PR are less important.

(My idea about the best timing of a new release is 3.1.1 after October 16th. I want to simplify the output of inspectdb because the complete `models.py` is now really huge and it goes much deeper than other tools. Many new tables in every new Salesforce version are only new read-only views to new metadata, not real data tables.)