### PR TITLE
Fix inspectdb

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,8 +48,9 @@ Install, configure a Salesforce connection, create a Salesforce model and run.
      the Salesforce REST API Documentation. Key and secret can be created on
      web by:
 
-     - Salesforce web > Setup > App Setup > Create > Apps > Connected apps >
-       New.
+     - Salesforce Classic > Setup > App Setup > Create > Apps > Connected apps >
+       New.  
+       or SalesForce Lightning > Setup > Apps > App Manager > New Connected App.
      - Click "Enable OAuth Settings" in API, then select "Access and manage
        your data (api)" from available OAuth Scopes.
      - Other red marked fields must be filled, but are not relevant for Django

--- a/README.rst
+++ b/README.rst
@@ -221,6 +221,12 @@ Advanced usage
    Consequently, the setting ``managed = True`` is related only to an alternate
    non SFDC database configured by ``SALESFORCE_DB_ALIAS``.)
 
+   There is probably no reason to collect old migrations of an application
+   that uses only SalesforceModel and all data are stored only in Salesforce.
+   Such old migrations can be easily deleted a new initial migration can be
+   created again if it would be necessary for offline tests and if that migrations
+   directory seems big and obsoleted.
+
 -  **Exceptions** - Custom exceptions instead of standard Django database
    exceptions are raised by Django-Salesforce to get more useful information.
    General exceptions are ``SalesforceError`` or a more general custom
@@ -271,6 +277,11 @@ Backwards-incompatible changes
 ------------------------------
 
 The most important:
+
+-  v1.0: The object ``salesforce.backend.operations.DefaultedOnCreate`` in an incidental
+   old migration should be rewritten to new ``salesforce.fields.DefaultedOnCreate``, but
+   old migrations are unnecessary usually.
+
 -  v0.9: This is the last version that suports Django 1.10 and Python 2.7 and 3.4
 
 -  v0.8: The default Meta option if now ``managed = True``, which is an important

--- a/salesforce/__init__.py
+++ b/salesforce/__init__.py
@@ -22,4 +22,4 @@ log = logging.getLogger(__name__)
 
 # Default version of Force.com API.
 # It can be customized by settings.DATABASES['salesforce']['API_VERSION']
-API_VERSION = '49.0'  # Summer '20
+API_VERSION = '50.0'  # Winter '21

--- a/salesforce/auth.py
+++ b/salesforce/auth.py
@@ -343,8 +343,8 @@ class SfdxWebAuth(StaticGlobalAuth):
 
             data = self.sfdx(cmd)
             if data['username'] != user:
-                raise SalesforceAuthError("Login by %r is requied, but you have loggedthe required username is %r" %
-                                          (data['username'], user))
+                raise SalesforceAuthError("Login by %r is requied, but you have logged in as a different "
+                                          "user %r" % (user, data['username']))
         return {'access_token': data['accessToken'], 'instance_url': data['instanceUrl']}
 
     def ask_sfdx_org_data(self, user: str) -> Dict[str, Any]:

--- a/salesforce/backend/introspection.py
+++ b/salesforce/backend/introspection.py
@@ -181,7 +181,11 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             params['help_text'] = field['inlineHelpText']
         if field['picklistValues']:
             params['choices'] = [(x['value'], x['label']) for x in field['picklistValues'] if x['active']]
-            params['max_len'] = max(len(x['value']) for x in field['picklistValues'] if x['active'])
+            if len(repr(params['choices'])) < 4000:
+                params['max_len'] = max(len(x['value']) for x in field['picklistValues'] if x['active'])
+            else:
+                params['ref_comment'] = 'Too long choices skipped'
+                del params['choices']
         if field['type'] == 'reference' and not self.references_to(field):
             if not field['referenceTo']:
                 params['ref_comment'] = 'No Reference to a table'

--- a/salesforce/backend/manager.py
+++ b/salesforce/backend/manager.py
@@ -10,8 +10,7 @@ Salesforce object manager. (like django.db.models.manager)
 
 Use a custom QuerySet to generate SOQL queries and results.
 
-This module is important for run-time, ignored in type checking and
-correct results are made by by sustomized django-stubs (django-salesforce-stubs)
+This module requires a customized package django-stubs (django-salesforce-stubs)
 """
 
 import sys

--- a/salesforce/backend/operations.py
+++ b/salesforce/backend/operations.py
@@ -15,7 +15,6 @@ import django.db.backends.utils
 from django.db.backends.base.operations import BaseDatabaseOperations
 from salesforce.backend import DJANGO_30_PLUS
 from salesforce.dbapi.exceptions import SalesforceWarning
-from salesforce.defaults import DefaultedOnCreate, DEFAULTED_ON_CREATE  # noqa # for backward compatibility migrations
 
 BULK_BATCH_SIZE = 200
 
@@ -132,3 +131,11 @@ class DatabaseOperations(BaseDatabaseOperations):
         # A wildcard search is better than a search of '\\%' or '\\_', see #254
         return str(x)
         # return str(x).replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
+
+
+def DefaultedOnCreate(*args, **kwargs):
+    import salesforce.defaults
+    warnings.warn("Deprecated: the object DefaultedOnCreate should be imported from "
+                  "salesforce.fields or salesforce.defaults or salesforce.models, "
+                  "but not from salesforce.backend.operations")
+    return salesforce.defaults(*args, **kwargs)

--- a/salesforce/dbapi/driver.py
+++ b/salesforce/dbapi/driver.py
@@ -189,7 +189,7 @@ class RawConnection:
                 auth_data = self.sf_auth.authenticate_and_cache()
                 sf_instance_url = auth_data.get('instance_url')
                 sf_session = SfSession()
-                sf_session.auth = self.sf_auth
+                sf_session.auth = self.sf_auth  # a name for "requests" package
                 if sf_instance_url and sf_instance_url not in sf_session.adapters:
                     # a repeated mount to the same prefix would cause a warning about unclosed SSL socket
                     sf_requests_adapter = HTTPAdapter(max_retries=get_max_retries())

--- a/salesforce/defaults.py
+++ b/salesforce/defaults.py
@@ -1,9 +1,9 @@
 import datetime
 import decimal
 from pytz import utc
-from typing import Any, Callable, Dict, Optional, overload, Tuple, Type
+from typing import Any, Callable, Dict, Optional, overload, Tuple, Type, TYPE_CHECKING
 # from django.utils.deconstruct import deconstructible
-import salesforce.models
+import salesforce
 
 
 # --- DefaultedOnCreate ---
@@ -207,7 +207,10 @@ def DefaultedOnCreate(value: Any = None, internal_type: Optional[str] = None) ->
         klass = field_type_map[internal_type]
         return klass(klass.default)
     elif value is not None:
-        if isinstance(value, type) and issubclass(value, salesforce.models.Model):
+        if isinstance(value, type) and hasattr(value, '_salesforce_object'):
+            if TYPE_CHECKING:
+                import salesforce.models
+                assert issubclass(value, salesforce.models.Model)
             return foreign_key_factory_default(value)
         if callable(value):
             return CallableDefault(value)

--- a/salesforce/fields.py
+++ b/salesforce/fields.py
@@ -211,8 +211,9 @@ class DecimalField(SfField, models.DecimalField):
                 ret = Decimal(int(ret))
         return ret
 
-    # parameter "context" is for Django <= 1.11 (the same is in more classes here)
-    def from_db_value(self, value, expression, connection, context=None):
+    # a positional parameter "context" was in Django <= 1.11
+    # replaced by *args here to preven deprecation warning in Django 2.x
+    def from_db_value(self, value, expression, connection, *args):
         # pylint:disable=unused-argument
         # TODO refactor and move to the driver like in other backends
         if isinstance(value, float):
@@ -245,7 +246,9 @@ class DateTimeField(SfField, models.DateTimeField):
 class DateField(SfField, models.DateField):
     """DateField with sf_read_only attribute for Salesforce."""
 
-    def from_db_value(self, value, expression, connection, context=None):
+    # a positional parameter "context" was in Django <= 1.11
+    # replaced by *args here to preven deprecation warning in Django 2.x
+    def from_db_value(self, value, expression, connection, *args):
         # pylint:disable=unused-argument
         return self.to_python(value)
 
@@ -253,7 +256,9 @@ class DateField(SfField, models.DateField):
 class TimeField(SfField, models.TimeField):
     """TimeField with sf_read_only attribute for Salesforce."""
 
-    def from_db_value(self, value, expression, connection, context=None):
+    # a positional parameter "context" was in Django <= 1.11
+    # replaced by *args here to preven deprecation warning in Django 2.x
+    def from_db_value(self, value, expression, connection, *args):
         # pylint:disable=unused-argument
         return self.to_python(value)
 

--- a/salesforce/management/commands/inspectdb.py
+++ b/salesforce/management/commands/inspectdb.py
@@ -36,6 +36,8 @@ class Command(InspectDBCommand):
             connection.introspection.is_tooling_api = self.tooling_api
 
             self.db_module = 'salesforce'
+            if options['table']:
+                options['table'] = [sf_introspection.SfProtectName(x) for x in options['table']]
             for line in self.handle_inspection(options):
                 line = line.replace(" Field renamed because it contained more than one '_' in a row.", "")
                 line = re.sub(' #$', '', line)

--- a/salesforce/testrunner/example/models.py
+++ b/salesforce/testrunner/example/models.py
@@ -42,6 +42,7 @@ class User(SalesforceModel):
     LastName = models.CharField(max_length=80)
     FirstName = models.CharField(max_length=40)
     IsActive = models.BooleanField(default=False)
+    UserType = models.CharField(max_length=80)
 
 
 class AbstractAccount(SalesforceModel):

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -898,7 +898,9 @@ class BasicSOQLRoTest(TestCase, LazyTestMixin):
         salesforce.auth.oauth_data[sf_alias]['access_token'] = 'something invalid/expired'
         with self.assertWarns(SalesforceWarning) as cm:
             Contact(pk=contact_id).delete()
-            self.assertIn('ENTITY_IS_DELETED', cm.warnings[0].message.args[0])
+            message = cm.warnings[0].message
+            assert isinstance(message, SalesforceWarning)
+            self.assertIn('ENTITY_IS_DELETED', message.args[0])
         with self.assertWarns(SalesforceWarning) as cm:
             # Id of completely deleted item or fake but valid item.
             Contact(pk='003000000000000AAA').delete()

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -330,7 +330,8 @@ class BasicSOQLRoTest(TestCase, LazyTestMixin):
         finally:
             contact.delete()
         # Verify that an explicit value is possible for this field.
-        other_user_obj = User.objects.exclude(Username=current_user).filter(IsActive=True)[0]
+        other_user_obj = (User.objects.exclude(Username=current_user)
+                          .filter(IsActive=True, UserType='Standard')[0])
         contact = Contact(first_name='sf_test', last_name='your',
                           owner=other_user_obj)
         contact.save()

--- a/salesforce/tests/test_utils.py
+++ b/salesforce/tests/test_utils.py
@@ -35,7 +35,8 @@ class UtilitiesTest(TestCase):
             # print("Response from convertLead: " +
             #       ', '.join('%s: %s' % (k, v) for k, v in sorted(ret.items())))
             expected_names = set(('accountId', 'contactId', 'leadId', 'opportunityId', 'success'))
-            self.assertEqual(set(ret), expected_names)
+            # The field 'relatedPersonAccountId' is present in the instances ver. 51.0+ Spring '21
+            self.assertEqual(set(ret).difference(['relatedPersonAccountId']), expected_names)
             self.assertEqual(ret['success'], 'true')
             # merge the new Account with the second Lead
             ret2 = convert_lead(lead2, doNotCreateOpportunity=True, accountId=ret['accountId'])

--- a/tests/inspectdb/slow_test.py
+++ b/tests/inspectdb/slow_test.py
@@ -111,7 +111,8 @@ def run():
                         assert test_class.objects.get(pk=obj.pk).last_modified_date > obj.last_modified_date
             stdout.write('\n')
     n_tables = len(sf.introspection.table_list_cache['sobjects'])
-    print('Result: {n_tables} tables, {n_read} reads tried, {n_no_data} no data, '
+    print('Inspectdb results:')
+    print('  {n_tables} tables, {n_read} reads tried, {n_no_data} no data, '
           '{n_read_errors} read errors, {n_write} writes tried, {n_write_errors} write errors'
           .format(n_tables=n_tables, n_read=n_read, n_no_data=n_no_data,
                   n_read_errors=n_read_errors, n_write=n_write, n_write_errors=n_write_errors))

--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -7,6 +7,8 @@ from typing import Dict
 import os
 import re
 import unittest
+from salesforce.backend import DJANGO_30_PLUS
+from salesforce.backend.test_helpers import expectedFailureIf
 
 
 def relative_path(path: str) -> str:
@@ -83,6 +85,11 @@ class ExportedModelTest(unittest.TestCase):
         self.assertRegex(line, r'#.* Master Detail Relationship \*')
         line = self.match_line('    created_by = ', classes_texts['Opportunity'])
         self.assertNotIn('Master Detail Relationship', line)
+
+    @expectedFailureIf(not DJANGO_30_PLUS)
+    def test_one_to_one_field_introspection(self) -> None:
+        """Test that OneToOneField is correctly introspected"""
+        self.assertTrue(any(('= models.OneToOneField(' in text) for text in classes_texts.values()))
 
 
 classes_texts = get_classes_texts()

--- a/tests/tooling/slow_test.py
+++ b/tests/tooling/slow_test.py
@@ -77,6 +77,8 @@ def run():
         'OrderManagementSettings', 'StandardAction', 'StandardValueSet',
         # in API 50.0 Winter'20
         'InventorySettings', 'SecuritySettings',
+        # in API 51.0 Spring '21
+        'EmployeeUserSettings',
     }
     problematic_write = {
         # any SalesforceError
@@ -171,7 +173,8 @@ def run():
     if new_problematic:
         print("\nnew_problematic:\n%r\n" % new_problematic)
     n_tables = len(sf.introspection.table_list_cache['sobjects'])
-    print('Result: {n_tables} tables, {n_read} reads tried, {n_no_data} no data, '
+    print('Tooling api results:')
+    print('  {n_tables} tables, {n_read} reads tried, {n_no_data} no data, '
           '{n_read_errors} read errors, {n_write} writes tried, {n_write_errors} write errors'
           .format(n_tables=n_tables, n_read=n_read, n_no_data=n_no_data,
                   n_read_errors=n_read_errors, n_write=n_write, n_write_errors=n_write_errors))

--- a/tests/tooling/slow_test.py
+++ b/tests/tooling/slow_test.py
@@ -75,6 +75,8 @@ def run():
         'ObjectSearchSetting', 'OpportunityInsightsSettings',
         'OpportunityListFieldsLabelMapping', 'OpportunityScoreSettings',
         'OrderManagementSettings', 'StandardAction', 'StandardValueSet',
+        # in API 50.0 Winter'20
+        'InventorySettings', 'SecuritySettings',
     }
     problematic_write = {
         # any SalesforceError
@@ -98,6 +100,10 @@ def run():
         'SurveySettings', 'SystemNotificationSettings', 'Territory2Settings',
         'TrialOrgSettings', 'User', 'UserEngagementSettings', 'UserInterfaceSettings',
         'UserManagementSettings', 'WebToXSettings', 'WorkDotComSettings',
+
+        # in API 50.0 Winter'20
+        'ExternalServicesSettings', 'RecommendationBuilderSettings',
+
         # ExpirationDate must be in the future.
         'TraceFlag',
         # silently not updated
@@ -147,11 +153,11 @@ def run():
                     obj.save(force_update=True)
                 except SalesforceError as exc:
                     new_problematic.append(db_table)
-                    stderr.write("\n************** SalesforceError %s %s\n" % (db_table, exc))
+                    stderr.write("\n************** write SalesforceError %s %s\n" % (db_table, exc))
                     n_write_errors += 1
                 except (TypeError, NotImplementedError) as exc:
                     new_problematic.append(db_table)
-                    stderr.write("\n************** %s %s %s\n" % (exc.__class__.__name__, db_table, exc))
+                    stderr.write("\n************** write %s %s %s\n" % (exc.__class__.__name__, db_table, exc))
                     n_write_errors += 1
                 else:
                     # object 'Topic' doesn't have the attribute 'last_modified_date'

--- a/tox.ini
+++ b/tox.ini
@@ -96,7 +96,7 @@ commands =
     rstcheck README.rst CHANGELOG.rst
 
 [testenv:typing]
-# any python >= 3.5.3
+# any python >= 3.5.3, < 3.9
 basepython = python3.7
 deps =
     mypy>=0.770


### PR DESCRIPTION
The first part is almost the same as the previous closed PR #276 Fix275, only with some fixed grammar typos and that Winter'21 is now available everywhere.

The second part is a series of fixes in order to can produce smaller `models.py` by `inspectdb`. A review of this part is desirable. I'm sure that the current solution is not perfect, but better than the previous state. 

A test passed by CI is not important enough. A review of better readability and usefulness of simplified output models.py is also important.