### PR TITLE
Version v3.2 for Django 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ install:
 script:
   - rstcheck README.rst
   - echo -e "SF_PK = 'Id'" > salesforce/testrunner/local_settings.py
-  - tox -r -e py36-dj31,py36-dj30,py36-dj22,py35-dj111,debug_toolbar
+  - tox -r -e py36-dj32,py36-dj31,py36-dj30,py36-dj22,py35-dj20,debug_toolbar

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,9 +14,13 @@ Some items here can be marked as "internal": not ready enough or
 experimental.
 
 
-Unpublished
------------
+[3.2] Unpublished
+-----------------
+* Add: Support for Django 3.2
+* Remove: Django 1.11
 * Fix: Backward compatibility with old migrations. #275
+* Fix: Simplify output of inspectdb if a choice is too huge
+  or if tables are restricted by table filter. #279
 
 
 [3.1] 2020-08-05

--- a/README.rst
+++ b/README.rst
@@ -279,6 +279,8 @@ Backwards-incompatible changes
 
 The most important:
 
+-  v3.2: Removed support for Django 1.11
+
 -  v1.0: The object ``salesforce.backend.operations.DefaultedOnCreate`` in an incidental
    old migration should be rewritten to new ``salesforce.fields.DefaultedOnCreate``, but
    old migrations are unnecessary usually.

--- a/README.rst
+++ b/README.rst
@@ -7,10 +7,10 @@ django-salesforce
 .. image:: https://badge.fury.io/py/django-salesforce.svg
    :target: https://pypi.python.org/pypi/django-salesforce
 
-.. image:: https://img.shields.io/badge/python-3.5%20%7C%203.6%20%7C%203.7%20%7C%203.8-blue
+.. image:: https://img.shields.io/badge/python-3.5%20%7C%203.6%20%7C%203.7%20%7C%203.8%20%7C%203.9-blue
    :target: https://www.python.org/
 
-.. image:: https://img.shields.io/badge/Django-1.11%2C%202.0%2C%202.1%2C%202.2%2C%203.0%2C%203.1-blue.svg
+.. image:: https://img.shields.io/badge/Django-2.0%2C%202.1%2C%202.2%2C%203.0%2C%203.1%20%7C%203.2-blue.svg
    :target: https://www.djangoproject.com/
 
 This library allows you to load, edit and query the objects in any Salesforce instance
@@ -19,8 +19,8 @@ for most uses. It works by integrating with the Django ORM, allowing access to
 the objects in your SFDC instance (Salesforce .com) as if they were in a
 traditional database.
 
-Python 3.5.3 to 3.8, Django 1.11 to 3.1.
-(Tested also with Python 3.9.0b4)
+Python 3.5.3 to 3.9, Django 2.0 to 3.2.
+(Tested also with Python 3.10.0a6)
 
 
 Quick Start

--- a/coverage_run.sh
+++ b/coverage_run.sh
@@ -2,7 +2,7 @@
 # expects that "tox" has been run
 COVERAGE=.tox/py37-dj21/bin/coverage
 $COVERAGE run --source salesforce manage.py check >/dev/null
-for x in py35-dj111 py36-dj20 py37-dj21 py38-dj30; do
+for x in py35-dj20 py37-dj22 py38-dj30 py39-dj31; do
     .tox/${x}/bin/coverage run -a --source salesforce manage.py inspectdb --database=salesforce >/dev/null
     .tox/${x}/bin/coverage run -a --source salesforce manage.py test salesforce
 done

--- a/coverage_run.sh
+++ b/coverage_run.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # expects that "tox" has been run
-COVERAGE=.tox/py37-dj21/bin/coverage
+COVERAGE=.tox/py37-dj22/bin/coverage
 $COVERAGE run --source salesforce manage.py check >/dev/null
-for x in py35-dj20 py37-dj22 py38-dj30 py39-dj31; do
+for x in py35-dj20 py36-dj21 py38-dj30 py39-dj31; do
     .tox/${x}/bin/coverage run -a --source salesforce manage.py inspectdb --database=salesforce >/dev/null
     .tox/${x}/bin/coverage run -a --source salesforce manage.py test salesforce
 done

--- a/salesforce/__init__.py
+++ b/salesforce/__init__.py
@@ -16,10 +16,10 @@ from salesforce.dbapi.exceptions import (  # NOQA pylint:disable=unused-import,u
     IntegrityError as IntegrityError, DatabaseError as DatabaseError, SalesforceError as SalesforceError,
 )
 
-__version__ = "3.1"
+__version__ = "3.2"
 
 log = logging.getLogger(__name__)
 
 # Default version of Force.com API.
 # It can be customized by settings.DATABASES['salesforce']['API_VERSION']
-API_VERSION = '50.0'  # Winter '21
+API_VERSION = '51.0'  # Spring '21

--- a/salesforce/auth.py
+++ b/salesforce/auth.py
@@ -330,6 +330,7 @@ class SfdxWebAuth(StaticGlobalAuth):
     no private data are saved to disk by django-salesforce, only data by sfdx
     """
     required_fields = ['ENGINE', 'HOST', 'USER']
+    data = None  # type:Dict[str, Any]
 
     def authenticate(self) -> Dict[str, str]:
         host = self.settings_dict['HOST']
@@ -362,7 +363,8 @@ class SfdxWebAuth(StaticGlobalAuth):
             self.data = {}
             # proc.returncode is the same as json "status" (and json "exitCode" if not zero)
             try:
-                data = json.loads(stdout)  # type: Dict[str, Any]
+                data = json.loads(stdout)
+                assert isinstance(data, dict)
                 msg = "SFDX error {}: {}".format(data['name'], data['message'])
                 if data['name'] in no_raise.split(','):
                     return data
@@ -580,7 +582,7 @@ class TimeStatistics:
     @staticmethod
     def domain(url: str) -> str:
         match = re.match(r'^(?:https|mock)://([^/]*)/?', url)
-        assert(match)
+        assert match
         return match.groups()[0]
 
 

--- a/salesforce/backend/__init__.py
+++ b/salesforce/backend/__init__.py
@@ -33,7 +33,6 @@ import re
 
 import django
 
-DJANGO_20_PLUS = django.VERSION[:2] >= (2, 0)
 DJANGO_21_PLUS = django.VERSION[:2] >= (2, 1)
 DJANGO_22_PLUS = django.VERSION[:2] >= (2, 2)
 DJANGO_30_PLUS = django.VERSION[:2] >= (3, 0)

--- a/salesforce/backend/__init__.py
+++ b/salesforce/backend/__init__.py
@@ -37,10 +37,11 @@ DJANGO_20_PLUS = django.VERSION[:2] >= (2, 0)
 DJANGO_21_PLUS = django.VERSION[:2] >= (2, 1)
 DJANGO_22_PLUS = django.VERSION[:2] >= (2, 2)
 DJANGO_30_PLUS = django.VERSION[:2] >= (3, 0)
-DJANGO_31_PLUS = django.VERSION[:2] >= (3, 1)  # still only a development version exists
+DJANGO_31_PLUS = django.VERSION[:2] >= (3, 1)
+DJANGO_32_PLUS = django.VERSION[:2] >= (3, 2)
 is_dev_version = django.VERSION[3:] and re.match('(alpha|beta|rc)', django.VERSION[3])
-if django.VERSION[:2] < (1, 11) or django.VERSION[:2] > (3, 1) and not is_dev_version:
-    raise ImportError("Django version between 1.11 and 3.1 is required "
+if django.VERSION[:2] < (2, 0) or django.VERSION[:2] > (3, 2) and not is_dev_version:
+    raise ImportError("Django version between 2.0 and 3.2 is required "
                       "for this django-salesforce.")
     # Usually three or more blocking issues can be expected by every
     # new major Django version. Strict check before support is better.

--- a/salesforce/backend/base.py
+++ b/salesforce/backend/base.py
@@ -76,7 +76,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     def __init__(self, settings_dict, alias=None):
         if alias is None:
             alias = getattr(settings, 'SALESFORCE_DB_ALIAS', 'salesforce')
-        super(DatabaseWrapper, self).__init__(settings_dict, alias)
+        super().__init__(settings_dict, alias)
 
         self._is_sandbox = None  # type: Optional[bool]
 

--- a/salesforce/backend/compiler.py
+++ b/salesforce/backend/compiler.py
@@ -19,7 +19,7 @@ from django.db.transaction import TransactionManagementError
 import salesforce.backend.models_lookups   # noqa # required for activation of lookups
 from salesforce.backend import DJANGO_21_PLUS, DJANGO_30_PLUS, DJANGO_31_PLUS
 from salesforce.dbapi.driver import DatabaseError
-# pylint:no-else-return,too-many-branches,too-many-locals
+# pylint:disable=no-else-return,too-many-branches,too-many-locals
 
 AliasMapItems = List[Tuple[
     Optional[str],
@@ -36,7 +36,7 @@ class SQLCompiler(sql_compiler.SQLCompiler):
     soql_trans = None  # type: Optional[Dict[str, str]]
 
     def __init__(self, *args, **kwargs) -> None:
-        super(SQLCompiler, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.root_aliases = []  # type: List[str]
 
     def get_from_clause(self) -> Tuple[List[str], List[Any]]:
@@ -51,7 +51,7 @@ class SQLCompiler(sql_compiler.SQLCompiler):
         if self.root_aliases and len(self.root_aliases) == 1:
             root_table = self.soql_trans[self.root_aliases[0]]
         else:
-            sql_items, params = super(SQLCompiler, self).get_from_clause()
+            sql_items, params = super().get_from_clause()
             assert not params
             root_table, alias = sql_items[0].rsplit(' ', 1)
             msg = "Only queries with one top child model are supported by Salesforce. Use a subquery."
@@ -338,7 +338,7 @@ class SalesforceWhereNode(sql_where.WhereNode):
         # *** patch 1 (add) begin
         # # prepare SOQL translations
         if not isinstance(compiler, SQLCompiler):
-            return super(SalesforceWhereNode, self).as_sql(compiler, connection)
+            return super().as_sql(compiler, connection)
         soql_trans = compiler.query_topology()
         # *** patch 1 end
 
@@ -405,6 +405,7 @@ class SalesforceWhereNode(sql_where.WhereNode):
 
 
 class SQLInsertCompiler(sql_compiler.SQLInsertCompiler, SQLCompiler):  # type: ignore[misc] # noqa # as_sql
+
     if DJANGO_31_PLUS:
 
         def execute_sql(self, returning_fields=None):

--- a/salesforce/backend/features.py
+++ b/salesforce/backend/features.py
@@ -20,7 +20,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
 
     supports_select_for_update_with_limit = False
 
-    # features new in Django 1.11
     supports_select_union = False
     supports_select_intersection = False
     supports_select_difference = False

--- a/salesforce/backend/features.py
+++ b/salesforce/backend/features.py
@@ -55,3 +55,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     # versa.
 
     can_introspect_json_field = False  # Django 3.1+
+
+    supports_collation_on_charfield = False  # Django 3.2+
+    supports_collation_on_textfield = False
+    supports_non_deterministic_collations = False
+    supports_expression_indexes = False

--- a/salesforce/backend/indep.py
+++ b/salesforce/backend/indep.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.db.models import Field
 
 
-class LazyField(object):
+class LazyField:
     """A Field that can be later customized until it is binded to the final Model"""
     # It does not need a deserializer for migrations because it is never passed
     # to migration tracking before before activation to a normal field

--- a/salesforce/backend/introspection.py
+++ b/salesforce/backend/introspection.py
@@ -346,7 +346,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
 # pylint:disable=too-few-public-methods
 
 
-class SymbolicModelsName(object):
+class SymbolicModelsName:
     """A symbolic name from the `models` module.
     >>> from salesforce import models
     >>> assert models.READ_ONLY == 3

--- a/salesforce/backend/introspection.py
+++ b/salesforce/backend/introspection.py
@@ -22,13 +22,15 @@ from django.db.backends.utils import CursorWrapper as _Cursor  # for typing
 # require "simplejson" to ensure that it is available to "requests" hook.
 import simplejson  # NOQA pylint:disable=unused-import
 
+from salesforce.backend import DJANGO_32_PLUS
 import salesforce.fields
 
 log = logging.getLogger(__name__)
 
-FieldInfo = namedtuple(
+FieldInfo = namedtuple(  # type:ignore[misc]
     'FieldInfo',
     'name type_code display_size internal_size precision scale null_ok default'
+    + (' collation' if DJANGO_32_PLUS else '') +
     ' params'  # the last name 'params' is our extension for Salesforce
 )  # pylint:disable=invalid-name
 assert FieldInfo._fields[:-1] == BaseFieldInfo._fields
@@ -218,7 +220,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                 del params['max_len']
             # We prefer "length" over "byteLength" for "internal_size".
             # (because strings have usually: byteLength == 3 * length)
-            result.append(FieldInfo(
+            result.append(FieldInfo(  # type:ignore[call-arg] # problem with a conditional type
                 field['name'],       # name,
                 field['type'],       # type_code,
                 field['length'],     # display_size,

--- a/salesforce/backend/manager.py
+++ b/salesforce/backend/manager.py
@@ -19,7 +19,7 @@ from django.db.models import manager, Model
 from django.db.models.query import QuerySet
 
 from salesforce import router
-from salesforce.backend import query, DJANGO_20_PLUS
+from salesforce.backend import query
 
 _T = TypeVar("_T", bound=Model, covariant=True)
 
@@ -29,10 +29,6 @@ class SalesforceManager(manager.Manager, Generic[_T]):
     if sys.version_info[:2] < (3, 6):
         # this is a fix for Generic type issue https://github.com/python/typing/issues/498
         __copy__ = None
-
-    if not DJANGO_20_PLUS:
-        use_for_related_fields = True
-        silence_use_for_related_fields_deprecation = True  # pylint:disable=invalid-name  # name from Django
 
     def get_queryset(self, _alias: Optional[str] = None) -> 'QuerySet[_T]':
         """

--- a/salesforce/backend/manager.py
+++ b/salesforce/backend/manager.py
@@ -39,14 +39,14 @@ class SalesforceManager(manager.Manager, Generic[_T]):
         assert self.model is not None
         if router.is_sf_database(self.db) or alias_is_sf or is_extended_model:
             return query.SalesforceQuerySet(self.model, using=self.db)
-        return super(SalesforceManager, self).get_queryset()
+        return super().get_queryset()
 
     # def raw(self, raw_query, params=None, translations=None):
     #     if router.is_sf_database(self.db):
     #         q = models_sql_query.SalesforceRawQuery(raw_query, self.db, params)
     #         return query.SalesforceRawQuerySet(raw_query=raw_query, model=self.model, query=q,
     #                                            params=params, using=self.db)
-    #     return super(SalesforceManager, self).raw(raw_query, params=params, translations=translations)
+    #     return super().raw(raw_query, params=params, translations=translations)
 
     # methods of SalesforceQuerySet on a SalesfroceManager
 

--- a/salesforce/backend/models_lookups.py
+++ b/salesforce/backend/models_lookups.py
@@ -19,7 +19,7 @@ class Range(models.lookups.Range):
     def override_as_sql(self, compiler, connection):
         lhs, lhs_params = self.process_lhs(compiler, connection)
         rhs, rhs_params = self.process_rhs(compiler, connection)
-        assert tuple(rhs) == ('%s', '%s')  # tuple in Django 1.11+, list in old Django
+        assert rhs == ('%s', '%s')
         assert len(rhs_params) == 2
         params = lhs_params + [rhs_params[0]] + lhs_params + [rhs_params[1]]
         # The symbolic parameters %s are again substituted by %s. The real

--- a/salesforce/backend/models_sql_query.py
+++ b/salesforce/backend/models_sql_query.py
@@ -7,7 +7,6 @@ from django.conf import settings
 from django.db.models import Count, Model
 from django.db.models.sql import Query, RawQuery, constants
 
-from salesforce.backend import DJANGO_20_PLUS
 from salesforce.dbapi.driver import arg_to_soql
 
 _T = TypeVar("_T", bound=Model, covariant=True)
@@ -26,7 +25,7 @@ class SalesforceRawQuery(RawQuery):
 #         if self.cursor.rowcount > 0:
 #             return [converter(col) for col in self.cursor.first_row.keys() if col != 'attributes']
 #         # TODO hy: A more general fix is desirable with rewriting more code.
-#         return ['Id']  # originally [SF_PK] before Django 1.8.4
+#         return ['Id']
 #
 #     def _execute_query(self):
 #         self.cursor = connections[self.using].cursor()
@@ -74,13 +73,7 @@ class SalesforceQuery(Query, Generic[_T]):
         return self.get_compiler(sf_alias).as_sql()
 
     def clone(self, klass=None, memo=None) -> 'SalesforceQuery[_T]':  # pylint: disable=arguments-differ
-        if DJANGO_20_PLUS:
-            query = cast(SalesforceQuery, Query.clone(self))
-        else:
-            # pylint: disable=too-many-function-args
-            query = cast(SalesforceQuery, Query.clone(self, klass, memo))  # type: ignore[call-arg]  # noqa
-            query.sf_params = self.sf_params
-        return query
+        return cast(SalesforceQuery, Query.clone(self))
 
     def sf(self,
            query_all: Optional[bool] = None,

--- a/salesforce/backend/models_sql_query.py
+++ b/salesforce/backend/models_sql_query.py
@@ -36,7 +36,7 @@ class SalesforceRawQuery(RawQuery):
 #         return "<SalesforceRawQuery: %s; %r>" % (self.sql, tuple(self.params))
 #
 #     def __iter__(self):
-#         for row in super(SalesforceRawQuery, self).__iter__():
+#         for row in super().__iter__():
 #             yield [row[k] for k in self.get_columns()]
 
 
@@ -52,7 +52,7 @@ class SalesforceQuery(Query, Generic[_T]):
     Override aggregates.
     """
     def __init__(self, model: Optional[Type[_T]], *args, **kwargs) -> None:
-        super(SalesforceQuery, self).__init__(model, *args, **kwargs)
+        super().__init__(model, *args, **kwargs)
         self.max_depth = 1
         self.sf_params = SfParams()  # paramaters for Salesforce query instead of transaction control
 
@@ -116,11 +116,10 @@ class SalesforceQuery(Query, Generic[_T]):
         return bool(compiler.execute_sql(constants.SINGLE))
 
     def get_count(self, using: str) -> int:
-        # TODO maybe can be removed soon
         """
         Performs a COUNT() query using the current filter constraints.
         """
-        # customized because "Count('*')" is not possbel wit Salesforce and also not "__" in an alias
+        # customized because "Count('*')" is not possible with Salesforce and also not "__" in an alias
         obj = self.clone()
         obj.add_annotation(Count('pk'), alias='x_sf_count', is_summary=True)  # pylint: disable=no-member
         number = obj.get_aggregation(using, ['x_sf_count'])['x_sf_count']  # type: Optional[int] # pylint: disable=no-member # noqa

--- a/salesforce/backend/operations.py
+++ b/salesforce/backend/operations.py
@@ -122,7 +122,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         All filter elements in a WHERE clause must be a field compared with value.
         The same is necessary for boolean fields, e.g. IsActive=true
         """
-        False
+        return False
 
     def prep_for_like_query(self, x):
         """Prepare a value for use in a LIKE query."""
@@ -138,4 +138,4 @@ def DefaultedOnCreate(*args, **kwargs):
     warnings.warn("Deprecated: the object DefaultedOnCreate should be imported from "
                   "salesforce.fields or salesforce.defaults or salesforce.models, "
                   "but not from salesforce.backend.operations")
-    return salesforce.defaults(*args, **kwargs)
+    return salesforce.defaults.DefaultedOnCreate(*args, **kwargs)

--- a/salesforce/backend/query.py
+++ b/salesforce/backend/query.py
@@ -8,9 +8,8 @@
 """
 Salesforce object query and queryset customizations.  (like django.db.models.query)
 """
-from typing import Dict, Generic, Iterable, List, Optional, TYPE_CHECKING, Type, TypeVar
+from typing import Dict, Generic, Iterable, List, NoReturn, Optional, TYPE_CHECKING, Type, TypeVar
 import typing
-import warnings
 
 from django.conf import settings
 from django.db import NotSupportedError, models
@@ -19,7 +18,7 @@ from django.db.utils import DEFAULT_DB_ALIAS
 import django
 
 from salesforce.backend.indep import get_sf_alt_pk
-from salesforce.backend import compiler, DJANGO_20_PLUS, DJANGO_22_PLUS, DJANGO_30_PLUS
+from salesforce.backend import compiler, DJANGO_22_PLUS, DJANGO_30_PLUS
 from salesforce.backend.models_sql_query import SalesforceQuery
 from salesforce.router import is_sf_database
 import salesforce.backend.utils
@@ -71,11 +70,8 @@ class SalesforceQuerySet(models_query.QuerySet, Generic[_T]):
         """
         return self.sf(query_all=True)
 
-    def simple_select_related(self, *fields: str) -> 'SalesforceQuerySet[_T]':
-        if DJANGO_20_PLUS:
-            raise NotSupportedError("Obsoleted method .simple_select_related(), use .select_related() instead")
-        warnings.warn("Obsoleted method .simple_select_related(), use .select_related() instead")
-        return self.select_related(*fields)
+    def simple_select_related(self, *fields: str) -> NoReturn:
+        raise NotSupportedError("Obsoleted method .simple_select_related(), use .select_related() instead")
 
     def bulk_create(self, objs: Iterable[_T], batch_size: Optional[int] = None, ignore_conflicts: bool = False
                     ) -> List[_T]:
@@ -113,10 +109,7 @@ class SalesforceQuerySet(models_query.QuerySet, Generic[_T]):
         return clone
 
     def _chain(self, **kwargs) -> 'SalesforceQuerySet[_T]':
-        if DJANGO_20_PLUS:
-            return super()._chain(**kwargs)
-        else:
-            return self._clone(**kwargs)  # type: ignore[call-arg] # noqa
+        return super()._chain(**kwargs)
 
     def patch_insert_query(self, query: models.sql.Query) -> None:
         setattr(query, 'sf_params', self.query.sf_params)

--- a/salesforce/backend/query.py
+++ b/salesforce/backend/query.py
@@ -25,7 +25,8 @@ import salesforce.backend.utils
 
 _T = TypeVar("_T", bound=models.Model, covariant=True)
 if TYPE_CHECKING:
-    from salesforce.models import SalesforceModel  # noqa
+    from salesforce.models import SalesforceModel  # pylint:disable=cyclic-import # noqa
+    # pylint:enable=cyclic-import
 
 # class SalesforceRawQuerySet(query.RawQuerySet):
 #     def __len__(self):
@@ -82,7 +83,7 @@ class SalesforceQuerySet(models_query.QuerySet, Generic[_T]):
             for x in objs:
                 if x.pk is None:
                     x.pk = get_sf_alt_pk()
-        return super(SalesforceQuerySet, self).bulk_create(objs, batch_size=batch_size, **kwargs)
+        return super().bulk_create(objs, batch_size=batch_size, **kwargs)
 
     def sf(self,
            query_all: Optional[bool] = None,
@@ -108,8 +109,8 @@ class SalesforceQuerySet(models_query.QuerySet, Generic[_T]):
         )
         return clone
 
-    def _chain(self, **kwargs) -> 'SalesforceQuerySet[_T]':
-        return super()._chain(**kwargs)
+    # def _chain(self, **kwargs) -> 'SalesforceQuerySet[_T]':
+    #     return super()._chain(**kwargs)
 
     def patch_insert_query(self, query: models.sql.Query) -> None:
         setattr(query, 'sf_params', self.query.sf_params)

--- a/salesforce/backend/schema.py
+++ b/salesforce/backend/schema.py
@@ -17,7 +17,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         self.collect_sql = collect_sql
         # if self.collect_sql:
         #    self.collected_sql = []
-        super(DatabaseSchemaEditor, self).__init__(connection, collect_sql=collect_sql, atomic=atomic)
+        super().__init__(connection, collect_sql=collect_sql, atomic=atomic)
 
     # State-managing methods
 

--- a/salesforce/backend/utils.py
+++ b/salesforce/backend/utils.py
@@ -169,7 +169,7 @@ def extract_values_inner(row, query):
     return d
 
 
-class CursorWrapper(object):
+class CursorWrapper:
     """
     A wrapper that emulates the behavior of a database cursor.
 

--- a/salesforce/dbapi/driver.py
+++ b/salesforce/dbapi/driver.py
@@ -262,13 +262,12 @@ class RawConnection:
         if not errorhandler:
             # nothing is caught usually and error handler not used
             return self.handle_api_exceptions_inter(method, *url_parts, **kwargs)
-        else:
-            try:
-                return self.handle_api_exceptions_inter(method, *url_parts, **kwargs)
-            except (SalesforceError, requests.exceptions.RequestException):
-                exc_class, exc_value, _ = sys.exc_info()
-                errorhandler(self, cursor_context, exc_class, exc_value)
-                raise
+        try:
+            return self.handle_api_exceptions_inter(method, *url_parts, **kwargs)
+        except (SalesforceError, requests.exceptions.RequestException):
+            exc_class, exc_value, _ = sys.exc_info()
+            errorhandler(self, cursor_context, exc_class, exc_value)
+            raise
 
     def handle_api_exceptions_inter(self, method: str, *url_parts: str, **kwargs: Any) -> requests.Response:
         """The main (middle) part - it is enough if no error occurs."""
@@ -867,7 +866,6 @@ sql_conversions = {}  # type: Dict[Type[Any], ConversionSqlFunc[Any]]
 
 subclass_conversions = []  # type: List[type]
 
-# pylint:disable=bad-whitespace
 register_conversion(int,             json_conv=str)
 register_conversion(float,           json_conv=lambda o: '%.15g' % o)
 register_conversion(type(None),      json_conv=lambda s: None,          sql_conv=lambda s: 'NULL')
@@ -878,7 +876,6 @@ register_conversion(datetime.datetime, json_conv=date_literal)
 register_conversion(datetime.time,   json_conv=lambda d: datetime.time.strftime(d, "%H:%M:%S.%fZ"))
 register_conversion(decimal.Decimal, json_conv=float, subclass=True)
 # the type models.Model is registered from backend, because it is a Django type
-# pylint:enable=bad-whitespace
 
 
 def merge_dict(dict_1: Dict[Any, Any], *other: Dict[Any, Any], **kw: Any) -> Dict[Any, Any]:

--- a/salesforce/dbapi/exceptions.py
+++ b/salesforce/dbapi/exceptions.py
@@ -3,8 +3,9 @@
 from importlib import import_module
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Type, Union
 import json
-import requests  # noqa
 import warnings
+
+import requests  # noqa
 # pylint:disable=too-few-public-methods
 
 
@@ -59,7 +60,7 @@ class SalesforceWarning(Warning):
         self.response = None  # type: Optional[GenResponse]
         self.verbs = None  # type: Optional[Set[str]]
         message = prepare_exception(self, messages, response, verbs)
-        super(SalesforceWarning, self).__init__(message)
+        super().__init__(message)
 
 
 class Error(Exception):
@@ -77,7 +78,7 @@ class Error(Exception):
         self.response = None  # type: Optional[GenResponse]
         self.verbs = None  # type: Optional[Set[str]]
         message = prepare_exception(self, messages, response, verbs)
-        super(Error, self).__init__(message)
+        super().__init__(message)
 
 
 class InterfaceError(Error):

--- a/salesforce/dbapi/subselect.py
+++ b/salesforce/dbapi/subselect.py
@@ -44,7 +44,7 @@ pattern_aggregation = re.compile(r'\b(?:{})(?=\()'.format('|'.join(AGGREGATION_W
 pattern_groupby = re.compile(r'\bGROUP BY\b', re.I)
 
 
-class QQuery(object):
+class QQuery:
     """Parse the SOQL query to an object useful to correctly interpret a response.
 
     public methods:

--- a/salesforce/dbapi/test_helpers.py
+++ b/salesforce/dbapi/test_helpers.py
@@ -17,7 +17,7 @@ def expectedFailureIf(condition: bool) -> Callable[[TestMethod], TestMethod]:
     return lambda func: func
 
 
-class QuietSalesforceErrors(object):
+class QuietSalesforceErrors:
     """Context manager that helps expected SalesforceErrors to be not logged too verbose.
 
     It works on the default Salesforce connection. It can be nested.

--- a/salesforce/defaults.py
+++ b/salesforce/defaults.py
@@ -1,7 +1,7 @@
 import datetime
 import decimal
-from pytz import utc
 from typing import Any, Callable, Dict, Optional, overload, Tuple, Type, TYPE_CHECKING
+from pytz import utc
 # from django.utils.deconstruct import deconstructible
 import salesforce
 
@@ -209,7 +209,7 @@ def DefaultedOnCreate(value: Any = None, internal_type: Optional[str] = None) ->
     elif value is not None:
         if isinstance(value, type) and hasattr(value, '_salesforce_object'):
             if TYPE_CHECKING:
-                import salesforce.models
+                import salesforce.models  # pylint:disable=cyclic-import
                 assert issubclass(value, salesforce.models.Model)
             return foreign_key_factory_default(value)
         if callable(value):

--- a/salesforce/fields.py
+++ b/salesforce/fields.py
@@ -138,10 +138,8 @@ class SfField(models.Field):
                 column = self.sf_namespace + column + '__c'
         return attname, column
 
-    def contribute_to_class(self, cls, name, private_only=False, **kwargs):
-        # More arguments are in Django 1.11 than in Django 2.0, therefore we use the universal **kwargs
-        # pylint:disable=arguments-differ
-        super(SfField, self).contribute_to_class(cls, name, private_only=private_only, **kwargs)
+    def contribute_to_class(self, cls, name, private_only=False):
+        super(SfField, self).contribute_to_class(cls, name, private_only=private_only)
         if self.sf_custom is None and hasattr(cls._meta, 'sf_custom'):
             # Only custom fields in models explicitly marked by
             # Meta custom=True are recognized automatically - for
@@ -211,9 +209,7 @@ class DecimalField(SfField, models.DecimalField):
                 ret = Decimal(int(ret))
         return ret
 
-    # a positional parameter "context" was in Django <= 1.11
-    # replaced by *args here to preven deprecation warning in Django 2.x
-    def from_db_value(self, value, expression, connection, *args):
+    def from_db_value(self, value, expression, connection):
         # pylint:disable=unused-argument
         # TODO refactor and move to the driver like in other backends
         if isinstance(value, float):
@@ -246,9 +242,7 @@ class DateTimeField(SfField, models.DateTimeField):
 class DateField(SfField, models.DateField):
     """DateField with sf_read_only attribute for Salesforce."""
 
-    # a positional parameter "context" was in Django <= 1.11
-    # replaced by *args here to preven deprecation warning in Django 2.x
-    def from_db_value(self, value, expression, connection, *args):
+    def from_db_value(self, value, expression, connection):
         # pylint:disable=unused-argument
         return self.to_python(value)
 
@@ -256,9 +250,7 @@ class DateField(SfField, models.DateField):
 class TimeField(SfField, models.TimeField):
     """TimeField with sf_read_only attribute for Salesforce."""
 
-    # a positional parameter "context" was in Django <= 1.11
-    # replaced by *args here to preven deprecation warning in Django 2.x
-    def from_db_value(self, value, expression, connection, *args):
+    def from_db_value(self, value, expression, connection):
         # pylint:disable=unused-argument
         return self.to_python(value)
 

--- a/salesforce/fields.py
+++ b/salesforce/fields.py
@@ -86,7 +86,7 @@ class SalesforceAutoField(fields.AutoField):
             # with the same default SalesforceAutoField. Therefore the second should be
             # ignored.
             return
-        super(SalesforceAutoField, self).contribute_to_class(cls, name, **kwargs)
+        super().contribute_to_class(cls, name, **kwargs)
         cls._meta.auto_field = self
 
 
@@ -110,7 +110,7 @@ class SfField(models.Field):
         self.sf_namespace = ''
         if kwargs.get('default') is DEFAULTED_ON_CREATE:
             kwargs['default'] = DefaultedOnCreate(internal_type=self.get_internal_type())
-        super(SfField, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def get_attname_column(self) -> Tuple[str, str]:
         """
@@ -139,7 +139,7 @@ class SfField(models.Field):
         return attname, column
 
     def contribute_to_class(self, cls, name, private_only=False):
-        super(SfField, self).contribute_to_class(cls, name, private_only=private_only)
+        super().contribute_to_class(cls, name, private_only=private_only)
         if self.sf_custom is None and hasattr(cls._meta, 'sf_custom'):
             # Only custom fields in models explicitly marked by
             # Meta custom=True are recognized automatically - for
@@ -202,7 +202,7 @@ class DecimalField(SfField, models.DecimalField):
     def to_python(self, value):
         if str(value) == '':
             return value
-        ret = super(DecimalField, self).to_python(value)
+        ret = super().to_python(value)
         if ret is not None and self.decimal_places == 0:
             # this is because Salesforce has no numeric integer type
             if ret == int(ret):
@@ -232,7 +232,7 @@ class BooleanField(SfField, models.BooleanField):
     a default value. Implicit default is False if not specified.
     """
     def __init__(self, default=False, **kwargs):
-        super(BooleanField, self).__init__(default=default, **kwargs)
+        super().__init__(default=default, **kwargs)
 
 
 class DateTimeField(SfField, models.DateTimeField):

--- a/salesforce/management/commands/inspectdb.py
+++ b/salesforce/management/commands/inspectdb.py
@@ -9,9 +9,10 @@ from salesforce.backend import introspection as sf_introspection
 
 
 class Command(InspectDBCommand):
+    tooling_api = None  # type:bool
 
     def add_arguments(self, parser):
-        super(Command, self).add_arguments(parser)
+        super().add_arguments(parser)
         parser.add_argument('--concise-db-column', action='store_true', dest='concise_db_column',
                             help="Export 'db_column' only if it is necessary and can not be reconstructed "
                             "from the name or 'custom'")
@@ -48,11 +49,10 @@ class Command(InspectDBCommand):
                 line = re.sub(' #$', '', line)
                 self.stdout.write("%s\n" % line)
         else:
-            super(Command, self).handle(**options)
+            super().handle(**options)
 
     def get_field_type(self, connection, table_name, row):
-        field_type, field_params, field_notes = (super(Command, self)
-                                                 .get_field_type(connection, table_name, row))
+        field_type, field_params, field_notes = super().get_field_type(connection, table_name, row)
         if connection.vendor == 'salesforce':
             if 'ref_comment' in row.params:
                 field_notes.append(row.params.pop('ref_comment'))
@@ -100,8 +100,7 @@ class Command(InspectDBCommand):
                     field_notes.append('Master Detail Relationship %s' % relationship_order)
                 field_params.update(fields_map)
         else:
-            new_name, field_params, field_notes = (super(Command, self)
-                                                   .normalize_col_name(col_name, used_column_names, is_relation))
+            new_name, field_params, field_notes = super().normalize_col_name(col_name, used_column_names, is_relation)
         return new_name, field_params, field_notes
 
     # the parameter 'is_view' has been since Django 2.1 and 'is_partition' since Django 2.2

--- a/salesforce/models.py
+++ b/salesforce/models.py
@@ -25,7 +25,6 @@ from django.db.models.base import ModelBase
 from django.db.models import PROTECT, DO_NOTHING  # NOQA pylint:disable=unused-wildcard-import,wildcard-import
 # from django.db.models import CASCADE, PROTECT, SET_NULL, SET, DO_NOTHING
 
-from salesforce.backend import DJANGO_20_PLUS
 from salesforce.defaults import DefaultedOnCreate, DEFAULTED_ON_CREATE
 from salesforce.fields import SalesforceAutoField, SF_PK, SfField, ForeignKey
 from salesforce.fields import NOT_UPDATEABLE, NOT_CREATEABLE, READ_ONLY
@@ -120,8 +119,6 @@ else:
         class Meta:
             abstract = True
             base_manager_name = 'base_manager'
-            if not DJANGO_20_PLUS:
-                manager_inheritance_from_future = True
 
         # Name of primary key 'Id' can be easily changed to 'id'
         # by "settings.SF_PK='id'".

--- a/salesforce/models.py
+++ b/salesforce/models.py
@@ -126,7 +126,7 @@ else:
                                  verbose_name='ID', auto_created=True)
 
 
-class ModelTemplate(object):
+class ModelTemplate:
     Meta = SalesforceModel.Meta
 
 

--- a/salesforce/models_extend.py
+++ b/salesforce/models_extend.py
@@ -52,16 +52,16 @@ class SfCharAutoField(SalesforceAutoField):
 
 
 if TYPE_CHECKING:
-    class SalesforceModel(models.Model, Generic[_T],  # type: ignore[no-redef] # noqa # redefined
+    class SalesforceModel(models.Model, Generic[_T],  # type:ignore[no-redef] # pylint:disable=function-redefined #noqa
                           metaclass=SalesforceModelBase):
         _salesforce_object = ...
 
-        def __init__(self, *args, **kwargs) -> None:
+        def __init__(self, *args, **kwargs) -> None:  # pylint:disable=super-init-not-called
             tmp = models.manager.Manager()  # type: models.manager.Manager[_T]
             self.objects = tmp
 else:
     # pylint:disable=too-few-public-methods,function-redefined
-    class SalesforceModel(models.Model, metaclass=SalesforceModelBase):
+    class SalesforceModel(models.Model, metaclass=SalesforceModelBase):  # pylint:disable=function-redefined
         """
         Abstract model class for Salesforce objects that can be saved to other db.
 
@@ -84,8 +84,8 @@ else:
             using = using or router.db_for_write(self.__class__, instance=self)
             if self.pk is None and not force_update and not is_sf_database(using):
                 self.pk = get_sf_alt_pk()
-            super(SalesforceModel, self).save(force_insert=force_insert, force_update=force_update,
-                                              using=using, update_fields=update_fields)
+            super().save(force_insert=force_insert, force_update=force_update,
+                         using=using, update_fields=update_fields)
             if not isinstance(self.pk, str):
                 raise ValueError("The primary key value is not assigned correctly")
 
@@ -95,4 +95,4 @@ else:
                 # the check "is_sf_database(using)" is used for something unexpected
                 if self.pk and not is_sf_database(using):
                     returning_fields = []
-                return super(SalesforceModel, self)._do_insert(manager, using, fields, returning_fields, raw)
+                return super()._do_insert(manager, using, fields, returning_fields, raw)

--- a/salesforce/models_extend.py
+++ b/salesforce/models_extend.py
@@ -23,7 +23,7 @@ Interesting not yet implemented ideas are:
 from typing import Generic, TYPE_CHECKING
 from django.db import models, router
 
-from salesforce.backend import DJANGO_20_PLUS, DJANGO_30_PLUS
+from salesforce.backend import DJANGO_30_PLUS
 from salesforce.backend.indep import get_sf_alt_pk
 from salesforce.models import *  # NOQA; pylint:disable=wildcard-import,unused-wildcard-import
 from salesforce.models import SalesforceAutoField, SalesforceModelBase, SF_PK, _T
@@ -77,8 +77,6 @@ else:
             # pylint:disable=duplicate-code
             abstract = True
             base_manager_name = 'objects'
-            if not DJANGO_20_PLUS:
-                manager_inheritance_from_future = True
 
         id = SfCharAutoField(primary_key=True, name=SF_PK, db_column='Id', verbose_name='ID', auto_created=True)
 

--- a/salesforce/router.py
+++ b/salesforce/router.py
@@ -17,14 +17,14 @@ from django.db import models
 
 def is_sf_database(db: Optional[str], model: models.Model = None) -> bool:
     """The alias is a Salesforce database."""
-    from django.db import connections
+    from django.db import connections  # pylint:disable=import-outside-toplevel
     if db is None:
         return hasattr(model, '_salesforce_object')
     engine = connections[db].settings_dict['ENGINE']
     return engine == 'salesforce.backend' or connections[db].vendor == 'salesforce'
 
 
-class ModelRouter(object):
+class ModelRouter:
     """
     Database router for Salesforce models.
     """

--- a/salesforce/testrunner/example/models.py
+++ b/salesforce/testrunner/example/models.py
@@ -6,8 +6,9 @@
 #
 
 from typing import Optional
-import django
 import types
+
+import django
 from django.conf import settings
 
 from salesforce import models

--- a/salesforce/testrunner/example/urls.py
+++ b/salesforce/testrunner/example/urls.py
@@ -5,10 +5,10 @@
 # See LICENSE.md for details
 #
 
-from django.conf.urls import url
+from django.urls import path
 from . import views
 
 urlpatterns = [
-    url(r'^$', views.list_accounts, name='list_accounts'),
-    url(r'^search/$', views.search_accounts, name='search_accounts'),
+    path(r'', views.list_accounts, name='list_accounts'),
+    path(r'search/', views.search_accounts, name='search_accounts'),
 ]

--- a/salesforce/testrunner/settings.py
+++ b/salesforce/testrunner/settings.py
@@ -195,6 +195,8 @@ LOGGING = {
 # version "django-salesforce < 0.5".
 # SF_PK = 'Id'
 
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'  # not important for Salesforce, but for Django warnings
+
 try:
     from salesforce.testrunner.local_settings import *  # NOQA pylint:disable=unused-wildcard-import,wildcard-import
 except ImportError:

--- a/salesforce/testrunner/urls.py
+++ b/salesforce/testrunner/urls.py
@@ -1,10 +1,10 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 
 from django.contrib import admin
 admin.autodiscover()
 
 urlpatterns = [
-    url(r'^', include('salesforce.testrunner.example.urls')),
-    url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
-    url(r'^admin/', admin.site.urls),
+    path(r'', include('salesforce.testrunner.example.urls')),
+    path(r'admin/doc/', include('django.contrib.admindocs.urls')),
+    path(r'admin/', admin.site.urls),
 ]

--- a/salesforce/tests/test_indep.py
+++ b/salesforce/tests/test_indep.py
@@ -2,7 +2,7 @@ import unittest
 from salesforce.backend.indep import LazyField
 
 
-class MyField(object):
+class MyField:
     # pylint:disable=invalid-name,too-few-public-methods
 
     def __init__(self, a=None, **kwargs):

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -176,7 +176,7 @@ class BasicSOQLRoTest(TestCase, LazyTestMixin):
             with self.lazy_assert_n_requests(1):
                 qs = Contact.objects.filter(account__Name='sf_test account').select_related('account')
                 contacts = list(qs)
-            with self.lazy_assert_n_requests(0):  # this fails in Django 2.0 - not cached
+            with self.lazy_assert_n_requests(0):
                 [x.account.Name for x in contacts]
             self.assertGreaterEqual(len(contacts), 1)
             self.lazy_check()

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -13,6 +13,7 @@ import logging
 import os
 import re
 import warnings
+from typing import Any, cast, List, TypeVar
 
 import pytz
 from django.conf import settings
@@ -20,7 +21,6 @@ from django.db import connections
 from django.db.models import Q, Avg, Count, Sum, Min, Max, Model, query as models_query
 from django.test import TestCase
 from django.utils import timezone
-from typing import Any, cast, List, TypeVar
 
 import salesforce
 from salesforce import router

--- a/salesforce/tests/test_unit.py
+++ b/salesforce/tests/test_unit.py
@@ -14,12 +14,12 @@ from salesforce.backend.test_helpers import LazyTestMixin
 
 class EasyCharField(models.CharField):
     def __init__(self, max_length=255, null=True, default='', **kwargs):
-        super(EasyCharField, self).__init__(max_length=max_length, null=null, default=default, **kwargs)
+        super().__init__(max_length=max_length, null=null, default=default, **kwargs)
 
 
 class EasyForeignKey(models.ForeignKey):
     def __init__(self, othermodel, on_delete=DO_NOTHING, **kwargs):
-        super(EasyForeignKey, self).__init__(othermodel, on_delete=on_delete, **kwargs)
+        super().__init__(othermodel, on_delete=on_delete, **kwargs)
 
 
 class TestField(TestCase):

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ def autosetup():
         # setuptools won't auto-detect Git managed files without this
         setup_requires=[] if not with_git else ["setuptools_git >= 0.4.2"],
 
-        install_requires=['django>=1.11'] + requirements_txt,
+        install_requires=['django>=2.0'] + requirements_txt,
 
         # metadata for upload to PyPI
         author="Freelancers Union",

--- a/tests/inspectdb/test.sh
+++ b/tests/inspectdb/test.sh
@@ -8,11 +8,10 @@
 #      after version switching
 
 
-echo "python manage.py inspectdb --database=salesforce >tests/inspectdb/models.py"
-if python manage.py inspectdb --database=salesforce --concise-db-column --traceback >tests/inspectdb/models.py; then
-
-    # Run both tests even if the first test fails. With old Django versions can
-    # the read/write test pass (useful information) though validation failed.
+echo "python manage.py inspectdb --database=salesforce --concise-db-column >tests/inspectdb/models.py"
+python manage.py inspectdb --database=salesforce --concise-db-column --traceback >tests/inspectdb/models.py
+RESULT_0=$?
+if [ $RESULT_0 == 0 ]; then
 
     echo "*** check"
     python manage.py check --settings=tests.inspectdb.settings --traceback
@@ -45,4 +44,6 @@ if python manage.py inspectdb --database=salesforce --concise-db-column --traceb
         echo ERROR
         false
     fi
+else
+    false
 fi

--- a/tests/inspectdb/urls.py
+++ b/tests/inspectdb/urls.py
@@ -1,9 +1,5 @@
 from django.contrib import admin
-from salesforce.backend import DJANGO_20_PLUS
-if DJANGO_20_PLUS:
-    from django.urls import path
-else:
-    from django.conf.urls import url as path
+from django.urls import path
 
 urlpatterns = [
     path('admin/', admin.site.urls),

--- a/tests/no_django_backend/django.py
+++ b/tests/no_django_backend/django.py
@@ -9,7 +9,7 @@ VERSION = (2, 1, 'mock')
 warnings.warn("Fake Django is for running some tests without Django.")
 
 
-class Settings(object):
+class Settings:
     pass
 
 

--- a/tests/test_general/test_helpers.py
+++ b/tests/test_general/test_helpers.py
@@ -66,7 +66,7 @@ class TestLazyAssertNoSetup(TestCase, LazyTestMixin):
 
     def setUp(self):
         # this overshadowed "setUp" in LazyTestMixin
-        # by omitting  super(..., self).setUp()
+        # by omitting  super().setUp()
         pass
 
     def test_fail(self):

--- a/tests/test_managers/settings.py
+++ b/tests/test_managers/settings.py
@@ -1,9 +1,10 @@
 from django.utils.crypto import get_random_string
 from salesforce.testrunner.settings import DATABASES  # noqa # necessary for setup
 
-SECRET_KEY = get_random_string()
+SECRET_KEY = get_random_string(length=32)
 
 INSTALLED_APPS = ['tests.test_managers']
 DATABASE_ROUTERS = ["salesforce.router.ModelRouter"]
 SF_LAZY_CONNECT = True
 USE_TZ = True
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'  # not important for Salesforce, but for Django warnings

--- a/tests/test_mixin/models.py
+++ b/tests/test_mixin/models.py
@@ -60,12 +60,12 @@ else:
         pass
 
 
-class DummyMixin(object):
+class DummyMixin:
     def some_overridden_method(self):
         pass
 
 
-class DummyMixin2(object):
+class DummyMixin2:
     pass
 
 

--- a/tests/test_mock/mocksf.py
+++ b/tests/test_mock/mocksf.py
@@ -64,7 +64,7 @@ APPLICATION_JSON = 'application/json;charset=UTF-8'
 # the first part are not test cases, but helpers for a mocked network: MockTestCase, MockRequest
 
 
-class MockRequestsSession(object):
+class MockRequestsSession:
     """Prepare mock session with expected requests + responses history
 
     expected:   iterable of MockJsonRequest
@@ -158,7 +158,7 @@ class MockRequestsSession(object):
         return getattr(settings, 'SF_MOCK_VERBOSITY', 1)
 
 
-class MockRequest(object):
+class MockRequest:
     """Recorded Mock request to be compared and response to be used
 
     for some unit tests offline
@@ -305,7 +305,7 @@ class MockTestCase(SimpleTestCase):
 # class MockXmlRequest - only with different default content types
 
 
-class MockResponse(object):
+class MockResponse:
     """Mock response for some unit tests offline"""
     default_type = None  # type: Optional[str]
 

--- a/tests/tooling/test.sh
+++ b/tests/tooling/test.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 echo "python manage.py inspectdb --database=salesforce --tooling-api >tests/tooling/models.py"
-if python manage.py inspectdb --database=salesforce --tooling-api --traceback >tests/tooling/models.py; then
-
-    # Run both tests even if the first test fails. With old Django versions can
-    # the read/write test pass (useful information) though validation failed.
+python manage.py inspectdb --database=salesforce --tooling-api --traceback >tests/tooling/models.py
+RESULT_0=$?
+if [ $RESULT_0 == 0 ]; then
 
     echo "*** test"
     python manage.py test --settings=tests.tooling.settings tests.tooling.tests
@@ -20,4 +19,6 @@ if python manage.py inspectdb --database=salesforce --tooling-api --traceback >t
         echo ERROR
         false
     fi
+else
+    false
 fi

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ deps =
     django-debug-toolbar
 commands = {envpython} manage.py test tests.t_debug_toolbar --settings=tests.t_debug_toolbar.settings
 
-[testenv:py36-dj21-pylint]
+[testenv:py39-dj31-pylint]
 setenv = DJANGO_SETTINGS_MODULE=salesforce.testrunner.settings
 commands = pylint --reports=no salesforce
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,12 +11,12 @@ minversion = 2.6
 envlist =
     docs_style
     typing
+    py39-dj32
     py39-dj31
     py38-dj30
     py37-dj22
-    py37-dj21
-    py36-dj20
-    py35-dj111
+    py36-dj21
+    py35-dj20
     py36-no_django
     debug_toolbar
 # Explicit combinations can be tested even though are not listed in ALL:
@@ -30,19 +30,20 @@ basepython =
     py37: python3.7
     py38: python3.8
     py39: python3.9
+    py310: python3.10
     pypy: pypy
     pypy3: pypy3
 deps =
-    dj111: Django~=1.11.17
     dj20: Django~=2.0.9
     dj21: Django~=2.1.4
     dj22: Django~=2.2.0
     dj30: Django~=3.0.0
     dj31: Django~=3.1.0
-    djdev: https://github.com/django/django/archive/master.zip
-    # local copy of django/origin master
-    # wget https://github.com/django/django/archive/master.zip -O django-22-dev.zip
-    # djdevlocal: django-22-dev.zip
+    dj32: Django~=3.2rc1
+    djdev: https://github.com/django/django/archive/main.zip
+    # local copy of django/origin main
+    # wget https://github.com/django/django/archive/main.zip -O django-32-dev.zip
+    # djdevlocal: django-32-dev.zip
     pylint: pylint
     pylint: pylint-django
     coverage
@@ -61,14 +62,12 @@ passenv = SLOW_TESTS
 
 # These other environments are tested by `tox -e ALL`:
 # (Especially useful is to add highest contra lowest Django combinations)
-[testenv:py37-dj111]
-[testenv:py35-dj21]
-[testenv:py36-djdev]
+[testenv:py310-djdev]
 
 [testenv:debug_toolbar]
 basepython = python3.6
 deps =
-    Django~=3.0.0
+    Django~=3.2rc1
     django-debug-toolbar
 commands = {envpython} manage.py test tests.t_debug_toolbar --settings=tests.t_debug_toolbar.settings
 


### PR DESCRIPTION
* Add support for Django 3.2
* Remove the old code for Django 1.11

The tests use Django 3.2 rc1 currently.
Please run tests also on Travis.
Our new release will be useful before final Django 3.2 (April 2021).