### PR TITLE
Fix lookup IsNull with .update() method

### DIFF
--- a/salesforce/backend/models_lookups.py
+++ b/salesforce/backend/models_lookups.py
@@ -9,6 +9,8 @@ from django.db.models import lookups
 class IsNull(models.lookups.IsNull):
     def override_as_sql(self, compiler, connection):  # pylint:disable=unused-argument
         # it must be relabeled if used for a children rows set
+        if compiler.soql_trans is None:
+            compiler.get_from_clause()
         sql, params = compiler.compile(self.lhs.relabeled_clone(compiler.soql_trans))
         return ('%s %s null' % (sql, ('=' if self.rhs else '!='))), params
 

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -587,6 +587,16 @@ class BasicSOQLRoTest(TestCase, LazyTestMixin):
             account_1.delete()
 
     @skipUnless(default_is_sf, "Default database should be any Salesforce.")
+    def test_queryset_update_foreign_key(self) -> None:
+        contact = Contact.objects.exclude(account=None)[0]
+        Contact.objects.filter(Id=contact.Id).update(account=contact.account)
+
+    @skipUnless(default_is_sf, "Default database should be any Salesforce.")
+    def test_queryset_none_filter_update(self) -> None:
+        """Test that this can be compiled and the SOQL is valid"""
+        Contact.objects.filter(pk=None).update(last_name='a')
+
+    @skipUnless(default_is_sf, "Default database should be any Salesforce.")
     def test_bulk_delete_and_update(self) -> None:
         """Delete two Accounts by one request.
         """


### PR DESCRIPTION
Fixed .update() method with IsNull lookup: `Contact.objects.filter(...=None).update(...)`

This was a secondary problem found when tried to reproduce an invalid issue #283.