### PR TITLE
resolves #299 SfCharAutoField internal_type

### DIFF
--- a/salesforce/models_extend.py
+++ b/salesforce/models_extend.py
@@ -42,7 +42,7 @@ class SfCharAutoField(SalesforceAutoField):
     #                       # but a fix by "_do_insert()" is better.
 
     def get_internal_type(self) -> str:
-        return 'CharField'
+        return 'AutoField'
 
     def db_type(self, connection: DatabaseWrapper) -> str:
         if connection.vendor != 'salesforce':


### PR DESCRIPTION
This PR attempts to fix the KeyError related to SfCharAutoFiel `internal_type` raised by Django System Check mechanism.