### PR TITLE
Version v4.1 for Django 4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ jobs:
         - python3.8 -V
       env: TOXENV=docs_style,typing,dj20-py36,dj22-py38,dj30-py36,dj32-py38
     - python: 3.9
-      env: TOXENV=dj40-py39,no_django-py39,debug_toolbar-dj32-py39
+      env: TOXENV=dj41-py39,dj40-py39,no_django-py39,debug_toolbar-dj32-py39

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,8 +14,8 @@ Some items here can be marked as "internal": not ready enough or
 experimental.
 
 
-[4.0] Unpublished
------------------
+[4.0] 2021-11-22
+----------------
 * Internal change: The default row type from salesforce Cursor is now a tuple,
   not a list
 * Fix: Invalid primary key from bulk_create([one_object]) in Django 3.0 #298

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,24 @@ Some items here can be marked as "internal": not ready enough or
 experimental.
 
 
+[4.1] Unpublished
+-----------------
+* Add: Support for Django 4.1
+* Add: Command ``inspectdb`` can introspect actual default values
+  of fields from a ``defaultValueFormula`` if it is a simple constant
+  like a number or a string.
+* Fix: A default value ``DefaultedOnCreate(value)`` is no longer created
+  by ``inspectdb`` in favour of a simple ``value``. If a simple default value
+  can not be known then a generic ``DEFAULTED_ON_CREATE`` is still used rarely
+  for default values created by a complicated or unknown function only
+  on Salesforce side. #280
+* Fix: Optionally don't use redundant table names before field names
+  if queried with ``.sf(minimal_aliases=True)``; important for some
+  special system objects #302
+* Fix: Tests with the newest Django, Salesforce, Python; including Python 3.11(beta)
+* Fix: Extended SalesforceModel with PostgreSQL backend and Django >= 3.0 #299
+
+
 [4.0] 2021-11-22
 ----------------
 * Internal change: The default row type from salesforce Cursor is now a tuple,

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ django-salesforce
 .. image:: https://img.shields.io/badge/python-3.6%20%7C%203.7%20%7C%203.8%20%7C%203.9%20%7C%203.10-blue
    :target: https://www.python.org/
 
-.. image:: https://img.shields.io/badge/Django-2.0%2C%202.1%2C%202.2%20%7C%203.0%2C%203.1%20%2C%203.2%20%7C%204.0-blue.svg
+.. image:: https://img.shields.io/badge/Django-2.0%2C%202.1%2C%202.2%20%7C%203.0%2C%203.1%20%2C%203.2%20%7C%204.0%2C%204.1-blue.svg
    :target: https://www.djangoproject.com/
 
 This library allows you to load, edit and query the objects in any Salesforce instance
@@ -19,7 +19,7 @@ for most uses. It works by integrating with the Django ORM, allowing access to
 the objects in your SFDC instance (Salesforce .com) as if they were in a
 traditional database.
 
-Python 3.6 to 3.10, Django 2.0 to 4.0. (Tested also with Python 3.11 alpha)
+Python 3.6 to 3.10, Django 2.0 to 4.1. (Tested also with Python 3.11 beta 4)
 
 
 Quick Start
@@ -215,15 +215,6 @@ Advanced usage
    and fields must have option ``db_column``, which is done by ``inspectdb``
    with default settings. Models exported by introspection ``inspectdb``
    do not specify the option ``managed`` because the default value is True.
-
-   Models managed by migrations on SFDC require the option ``sf_managed=True``.
-   Detaild are described in `docs Migrations <docs/migrations.rst>`__.
-
-   (It is safe. When migrations in SFDC will be supported by the next version
-   4.0.1 then only for explicitly selected fields and models and on
-   explicitly labeled SFDC databases.
-   Consequently, the setting ``managed = True`` alone is related only to
-   an alternate non SFDC database configured by ``SALESFORCE_DB_ALIAS``.)
 
    There is probably no reason now to collect old migrations of an application
    that uses only SalesforceModel if they are related to data stored only in Salesforce.

--- a/salesforce/__init__.py
+++ b/salesforce/__init__.py
@@ -20,6 +20,6 @@ from salesforce.dbapi.exceptions import (  # NOQA pylint:disable=unused-import,u
     IntegrityError as IntegrityError, DatabaseError as DatabaseError, SalesforceError as SalesforceError,
 )
 
-__version__ = "4.0"
+__version__ = "4.1"
 
 log = logging.getLogger(__name__)

--- a/salesforce/__init__.py
+++ b/salesforce/__init__.py
@@ -14,7 +14,7 @@ import logging
 
 # Default version of Force.com API.
 # It can be customized by settings.DATABASES['salesforce']['API_VERSION']
-API_VERSION = '54.0'  # Spring '22
+API_VERSION = '55.0'  # Summer '22
 
 from salesforce.dbapi.exceptions import (  # NOQA pylint:disable=unused-import,useless-import-alias,wrong-import-position
     IntegrityError as IntegrityError, DatabaseError as DatabaseError, SalesforceError as SalesforceError,

--- a/salesforce/backend/__init__.py
+++ b/salesforce/backend/__init__.py
@@ -41,8 +41,8 @@ DJANGO_32_PLUS = django.VERSION[:2] >= (3, 2)
 DJANGO_40_PLUS = django.VERSION[:2] >= (4, 0)
 DJANGO_41_PLUS = django.VERSION[:2] >= (4, 1)
 is_dev_version = django.VERSION[3:] and re.match('(alpha|beta|rc)', django.VERSION[3])
-if django.VERSION[:2] < (2, 0) or django.VERSION[:2] > (4, 0) and not is_dev_version:
-    raise ImportError("Django version between 2.0 and 4.0 is required "
+if django.VERSION[:2] < (2, 0) or django.VERSION[:2] > (4, 1) and not is_dev_version:
+    raise ImportError("Django version between 2.0 and 4.1 is required "
                       "for this django-salesforce.")
     # Usually three or more blocking issues can be expected by every
     # new major Django version. Strict check before support is better.

--- a/salesforce/backend/__init__.py
+++ b/salesforce/backend/__init__.py
@@ -39,6 +39,7 @@ DJANGO_30_PLUS = django.VERSION[:2] >= (3, 0)
 DJANGO_31_PLUS = django.VERSION[:2] >= (3, 1)
 DJANGO_32_PLUS = django.VERSION[:2] >= (3, 2)
 DJANGO_40_PLUS = django.VERSION[:2] >= (4, 0)
+DJANGO_41_PLUS = django.VERSION[:2] >= (4, 1)
 is_dev_version = django.VERSION[3:] and re.match('(alpha|beta|rc)', django.VERSION[3])
 if django.VERSION[:2] < (2, 0) or django.VERSION[:2] > (4, 0) and not is_dev_version:
     raise ImportError("Django version between 2.0 and 4.0 is required "

--- a/salesforce/backend/compiler.py
+++ b/salesforce/backend/compiler.py
@@ -30,6 +30,14 @@ AliasMapItems = List[Tuple[
 ]]
 
 
+class SfParams:  # like an immutable DataClass: clone when updating
+    def __init__(self):
+        self.query_all = False
+        self.all_or_none = None  # type: Optional[bool]
+        self.edge_updates = False
+        self.minimal_aliases = False
+
+
 class SQLCompiler(sql_compiler.SQLCompiler):
     """
     A subclass of the default SQL compiler for the SOQL dialect.
@@ -38,7 +46,12 @@ class SQLCompiler(sql_compiler.SQLCompiler):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
+        self.sf_params = SfParams()
         self.root_aliases = []  # type: List[str]
+
+    def set_sf_params(self, sf_params: SfParams) -> 'SQLCompiler':
+        self.sf_params = sf_params
+        return self
 
     def get_from_clause(self) -> Tuple[List[str], List[Any]]:
         """

--- a/salesforce/backend/compiler.py
+++ b/salesforce/backend/compiler.py
@@ -292,7 +292,7 @@ class SQLCompiler(sql_compiler.SQLCompiler):
         if self.soql_trans is not None:
             return self.soql_trans
         if not _alias_map_items and not self.query.alias_map:
-            # empty alias_map is possible due to field expr in Django 1.8
+            # empty alias_map is possible due to field expr
             return {}
         # Unified interface:
         #   alias_map_items = [(lhs, table, join_cols_, rhs),...]

--- a/salesforce/backend/compiler.py
+++ b/salesforce/backend/compiler.py
@@ -99,7 +99,18 @@ class SQLCompiler(sql_compiler.SQLCompiler):
                 return sql_field
             pre, field, post = '', sql_field, ''
         tab_name, field_name = field.split('.')
-        ret = "%s%s.%s%s" % (pre, soql_trans[tab_name], field_name, post)
+        if self.sf_params.minimal_aliases:
+            assert len(self.root_aliases) == 1
+            if tab_name == self.root_aliases[0]:
+                trans_tab_name = ''
+            else:
+                trans_root = soql_trans[self.root_aliases[0]]
+                assert soql_trans[tab_name].startswith(trans_root + '.')
+                trans_tab_name = soql_trans[tab_name].replace(trans_root + '.', '', 1)
+        else:
+            trans_tab_name = soql_trans[tab_name]
+        dot = '.' if trans_tab_name else ''
+        ret = "%s%s%s%s%s" % (pre, trans_tab_name, dot, field_name, post)
         if debug_ >= 2:
             print('** sf_fix_field: {!r} -> {!r}'.format(sql_field, ret))
         return ret

--- a/salesforce/backend/features.py
+++ b/salesforce/backend/features.py
@@ -64,3 +64,5 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_non_deterministic_collations = False
     supports_covering_indexes = False
     supports_expression_indexes = False
+
+    has_case_insensitive_like = True  # this is opposite to the default in Django 4.1

--- a/salesforce/backend/features.py
+++ b/salesforce/backend/features.py
@@ -58,11 +58,17 @@ class DatabaseFeatures(BaseDatabaseFeatures):
 
     can_introspect_json_field = False  # Django 3.1+
     supports_deferrable_unique_constraints = False
+    supports_json_field = False
 
     supports_collation_on_charfield = False  # Django 3.2+
     supports_collation_on_textfield = False
     supports_non_deterministic_collations = False
     supports_covering_indexes = False
     supports_expression_indexes = False
+    # django_test_expected_failures = set()  # maybe in the future
+    # django_test_skips = {}
 
-    has_case_insensitive_like = True  # this is opposite to the default in Django 4.1
+    supports_update_conflicts = False  # new in Django 4.1+
+    supports_update_conflicts_with_target = False
+    supports_logical_xor = False
+    has_case_insensitive_like = True  # this is opposite to the default in Django 4.1+

--- a/salesforce/backend/introspection.py
+++ b/salesforce/backend/introspection.py
@@ -148,6 +148,8 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
 
     def table_description_cache(self, table: str) -> Dict[str, Any]:
         if table not in self._table_description_cache:
+            if table == 'django_migrations':
+                raise ValueError("The internal table 'django_migrations' is not a normal Model.")
             log.debug('Request API URL: GET sobjects/%s/describe', table)
             response = self.connection.connection.handle_api_exceptions('GET', self.sobjects_prefix, table, 'describe/'
                                                                         )

--- a/salesforce/backend/introspection.py
+++ b/salesforce/backend/introspection.py
@@ -46,6 +46,7 @@ PROBLEMATIC_OBJECTS = [
     'AsyncOperationStatus',  # new in API 46.0 Summer '19
     'FlowExecutionErrorEvent',  # new in API 47.0 Winter '20 - missing 'Id'
     'FlowOrchestrationEvent',  # new in API 53.0 Winter '22
+    'DataObjectDataChgEvent',  # new in API 55.0 Summer '22 (no 'Id' field)
 ]
 
 # this global variable is for `salesforce.management.commands.inspectdb`

--- a/salesforce/backend/introspection.py
+++ b/salesforce/backend/introspection.py
@@ -204,7 +204,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             if field['defaultValue'] is None:
                 params['default'] = SymbolicModelsName('DEFAULTED_ON_CREATE')
             else:
-                params['default'] = SymbolicModelsName('DefaultedOnCreate', field['defaultValue'])
+                params['default'] = field['defaultValue']
         elif field['defaultValue'] is not None:
             params['default'] = field['defaultValue']
         if field['inlineHelpText']:

--- a/salesforce/backend/manager.py
+++ b/salesforce/backend/manager.py
@@ -60,7 +60,7 @@ class SalesforceManager(manager.Manager, Generic[_T]):
            query_all: Optional[bool] = None,
            all_or_none: Optional[bool] = None,
            edge_updates: Optional[bool] = None,
-           ) -> 'query.SalesforceQuerySet[_T]':
+           minimal_aliases: Optional[bool] = None) -> 'query.SalesforceQuerySet[_T]':
         # not dry, but explicit due to preferring type check of user code
         qs = self.get_queryset()
         assert isinstance(qs, query.SalesforceQuerySet)
@@ -68,4 +68,5 @@ class SalesforceManager(manager.Manager, Generic[_T]):
             query_all=query_all,
             all_or_none=all_or_none,
             edge_updates=edge_updates,
+            minimal_aliases=minimal_aliases,
         )

--- a/salesforce/backend/models_sql_query.py
+++ b/salesforce/backend/models_sql_query.py
@@ -112,7 +112,7 @@ class SalesforceQuery(Query, Generic[_T]):
 
     def has_results(self, using: Optional[str]) -> bool:
         q = self.clone()
-        compiler = q.get_compiler(using=using)  # pylint: disable=no-member
+        compiler = q.get_compiler(using=using)
         return bool(compiler.execute_sql(constants.SINGLE))
 
     def get_count(self, using: str) -> int:

--- a/salesforce/backend/query.py
+++ b/salesforce/backend/query.py
@@ -106,6 +106,7 @@ class SalesforceQuerySet(models_query.QuerySet, Generic[_T]):
            query_all: Optional[bool] = None,
            all_or_none: Optional[bool] = None,
            edge_updates: Optional[bool] = None,
+           minimal_aliases: Optional[bool] = None,
            ) -> 'SalesforceQuerySet[_T]':
         """Set additional parameters for queryset methods with Salesforce.
 
@@ -123,6 +124,7 @@ class SalesforceQuerySet(models_query.QuerySet, Generic[_T]):
             query_all=query_all,
             all_or_none=all_or_none,
             edge_updates=edge_updates,
+            minimal_aliases=minimal_aliases,
         )
         return clone
 

--- a/salesforce/tests/test_unit.py
+++ b/salesforce/tests/test_unit.py
@@ -210,6 +210,19 @@ class SfParamsTest(TestCase):
         self.assertEqual(qs.query.get_compiler('salesforce').sf_params.minimal_aliases, False)
         self.assertEqual(qs.sf(minimal_aliases=True).query.get_compiler('salesforce').sf_params.minimal_aliases, True)
 
+        # test that a normal SOQL is with table aliases
+        qs = Contact.objects.filter(first_name='Peter').values('last_name')
+        self.assertEqual(str(qs.query), "SELECT Contact.LastName FROM Contact WHERE Contact.FirstName = 'Peter'")
+
+        # test that superfluous talbe aliases can be removed by 'minimal_aliases'
+        expected_sql = "SELECT LastName FROM Contact WHERE FirstName = 'Peter'"
+        qs = Contact.objects.sf(minimal_aliases=True).filter(first_name='Peter').values('last_name')
+        self.assertEqual(str(qs.query), expected_sql)
+        qs = Contact.objects.filter(first_name='Peter').sf(minimal_aliases=True).values('last_name')
+        self.assertEqual(str(qs.query), expected_sql)
+        qs = Contact.objects.filter(first_name='Peter').values('last_name').sf(minimal_aliases=True)
+        self.assertEqual(str(qs.query), expected_sql)
+
 
 class RegisterConversionTest(TestCase):
     @staticmethod

--- a/salesforce/tests/test_unit.py
+++ b/salesforce/tests/test_unit.py
@@ -196,7 +196,7 @@ class SfParamsTest(TestCase):
         qs_1 = Contact.objects.all()
         qs_2 = qs_1.sf(query_all=True)
         qs_3 = qs_2.filter(first_name__gt='A')
-        # a valua is propagated to the next level, but not to the previous
+        # a value is propagated to the next level, but not to the previous
         self.assertTrue(qs_3.query.sf_params.query_all)
         self.assertFalse(qs_1.query.sf_params.query_all)
 

--- a/salesforce/tests/test_unit.py
+++ b/salesforce/tests/test_unit.py
@@ -189,6 +189,9 @@ class TestTopologyCompiler(TestCase):
 
 
 class SfParamsTest(TestCase):
+    # type checking of this test case is currently not possible
+    databases = '__all__'
+
     def test_params_handover_and_isolation(self):
         """Test that sp_params are propagated to the rest of the queryset chain
         but isolated from the previous part.
@@ -199,6 +202,13 @@ class SfParamsTest(TestCase):
         # a value is propagated to the next level, but not to the previous
         self.assertTrue(qs_3.query.sf_params.query_all)
         self.assertFalse(qs_1.query.sf_params.query_all)
+
+    def test_minimal_aliases(self):
+        """Test SOQL with minimal aliases without a table name of the main table"""
+        # test that 'minimal_aliases' attribute is passed from qs to a salesforce compiler
+        qs = Contact.objects.all()
+        self.assertEqual(qs.query.get_compiler('salesforce').sf_params.minimal_aliases, False)
+        self.assertEqual(qs.sf(minimal_aliases=True).query.get_compiler('salesforce').sf_params.minimal_aliases, True)
 
 
 class RegisterConversionTest(TestCase):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [flake8]
 max_line_length=119
-exclude=.git,.tox,.env,build,models1*.py,packages_,tests/inspectdb/models.py,tests/inspectdb/dependent_model/models_template.py,tests/tooling/models.py
+exclude=.git,.tox,.env,migrations,build,models1*.py,packages_,tests/inspectdb/models.py,tests/inspectdb/dependent_model/models_template.py,tests/tooling/models.py

--- a/tests/inspectdb/dependent_model/settings.py
+++ b/tests/inspectdb/dependent_model/settings.py
@@ -5,4 +5,4 @@ INSTALLED_APPS = [x for x in INSTALLED_APPS if not x.startswith('salesforce.test
 # INSTALLED_APPS += ('tests.inspectdb', 'tests.inspectdb.dependent_model')
 INSTALLED_APPS += ['tests.inspectdb.dependent_model.AutoModelConf',
                    'tests.inspectdb.dependent_model.DependentModelConf']
-ROOT_URLCONF = None
+ROOT_URLCONF = 'tests.no_urls'

--- a/tests/no_urls.py
+++ b/tests/no_urls.py
@@ -1,0 +1,1 @@
+urlpatterns = []  # type: ignore[var-annotated]

--- a/tests/test_app_label/settings.py
+++ b/tests/test_app_label/settings.py
@@ -4,4 +4,4 @@ from salesforce.testrunner.settings import INSTALLED_APPS
 
 INSTALLED_APPS = [x for x in INSTALLED_APPS if x != 'salesforce.testrunner.example']
 INSTALLED_APPS += ['tests.test_app_label.salesforce.apps.TestSalesForceConfig']
-ROOT_URLCONF = None
+ROOT_URLCONF = 'tests.no_urls'

--- a/tests/test_compatibility/settings.py
+++ b/tests/test_compatibility/settings.py
@@ -4,4 +4,4 @@ from salesforce.testrunner.settings import INSTALLED_APPS
 INSTALLED_APPS = [x for x in INSTALLED_APPS if x != 'salesforce.testrunner.example']
 INSTALLED_APPS += ['tests.test_compatibility']
 SF_PK = 'Id'
-ROOT_URLCONF = None
+ROOT_URLCONF = 'tests.no_urls'

--- a/tests/test_migrate/settings.py
+++ b/tests/test_migrate/settings.py
@@ -13,4 +13,4 @@ DATABASES = {
         'NAME': 'db_tmp_salesforce',
     },
 }
-ROOT_URLCONF = None
+ROOT_URLCONF = 'tests.no_urls'

--- a/tests/test_mixin/settings.py
+++ b/tests/test_mixin/settings.py
@@ -3,4 +3,4 @@ from salesforce.testrunner.settings import INSTALLED_APPS
 
 INSTALLED_APPS = [x for x in INSTALLED_APPS if x != 'salesforce.testrunner.example']
 INSTALLED_APPS += ['tests.test_mixin']
-ROOT_URLCONF = None
+ROOT_URLCONF = 'tests.no_urls'

--- a/tests/tooling/slow_test.py
+++ b/tests/tooling/slow_test.py
@@ -83,6 +83,9 @@ def run():
         'EinsteinAgentSettings',
         # in API 54.0 Spring '22
         'EinsteinDealInsightsSettings',
+        # in API 55.0 Summer '22
+        'IndustriesAutomotiveSettings', 'RelatedListColumnDefinition', 'RelatedListDefinition',
+        'SubscriptionManagementSettings', 'WarrantyLifecycleMgmtSettings',
     }
     problematic_write = {
         # any SalesforceError

--- a/tox.ini
+++ b/tox.ini
@@ -57,6 +57,7 @@ deps =
     # beatbox3
     git+https://github.com/hynekcer/beatbox-davisagli.git@7f628a789cba#egg=beatbox
     -rrequirements.txt
+    psycopg2-binary
 commands =
     {envpython} manage.py test salesforce tests.test_mock
     {toxinidir}/tests/tests.sh

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ deps =
     # wget https://github.com/django/django/archive/main.zip -O django-40-dev.zip
     # djdevlocal: django-40-dev.zip
     pylint: pylint~=2.8.0    # fixed version to not report too much
-    pylint: pylint-django
+    pylint: pylint-django<2.5
     debug_toolbar: django-debug-toolbar
     coverage
     # This Beatbox version works with Python 3 and 2.

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,6 @@ envlist =
 
 [testenv]
 basepython =
-    py35: python3.5
     py36: python3.6
     py37: python3.7
     py38: python3.8
@@ -44,7 +43,7 @@ deps =
     dj31: Django~=3.1.3   # py36-39
     dj32: Django~=3.2.0   # py36-39
     dj40: Django~=4.0.0   # py38-310
-    dj41: Django~=4.0rc1  # py38-310
+    dj41: Django~=4.1.0   # py38-310
     djdev: https://github.com/django/django/archive/main.zip
     # local copy of django/origin main
     # wget https://github.com/django/django/archive/main.zip -O django-40-dev.zip

--- a/tox.ini
+++ b/tox.ini
@@ -8,15 +8,16 @@
 envlist =
     docs_style
     typing
+    dj41-py310
     dj40-py310
     dj20-py36
     dj21-py37
     dj22-py38
     dj31-py39
-    # djdev-py38
+    # djdev-py311
     no_django-py38
     debug_toolbar-dj40-py38
-    # pylint-dj32-py38`
+    # pylint-dj41-py310`
 
 # Python versions for Travis are 3.6, 3.8, 3.9 (the lowest, the default in Travis, the highest in Travis)
 # Environments tested by Travis 
@@ -43,6 +44,7 @@ deps =
     dj31: Django~=3.1.3   # py36-39
     dj32: Django~=3.2.0   # py36-39
     dj40: Django~=4.0.0   # py38-310
+    dj41: Django~=4.0rc1  # py38-310
     djdev: https://github.com/django/django/archive/main.zip
     # local copy of django/origin main
     # wget https://github.com/django/django/archive/main.zip -O django-40-dev.zip
@@ -79,7 +81,7 @@ commands =
 [testenv:debug_toolbar-dj{20,32,40}-py{36,38,39}]
 commands = {envpython} manage.py test tests.t_debug_toolbar --settings=tests.t_debug_toolbar.settings
 
-[testenv:pylint-dj{20,21,22,30,31,32,40}-py{36,38,39}]
+[testenv:pylint-dj{20,21,22,30,31,32,40,41}-py{36,38,39,310}]
 setenv = DJANGO_SETTINGS_MODULE=salesforce.testrunner.settings
 commands = pylint --reports=no salesforce
 


### PR DESCRIPTION
Django 4.1rc1 has been released on July 19. We can release django-salesforce v4.1 now.

* Add: Support for Django 4.1
* Add: Command ``inspectdb`` can introspect actual default values
  of fields from a ``defaultValueFormula`` if it is a simple constant
  like a number or a string.
* Fix: A default value ``DefaultedOnCreate(value)`` is no longer created
  by ``inspectdb`` in favour of a simple ``value``. If a simple default value
  can not be known then a generic ``DEFAULTED_ON_CREATE`` is still used rarely
  for default values created by a complicated or unknown function only
  on Salesforce side. #280
* Fix: Optionally don't use redundant table names before field names
  if queried with ``.sf(minimal_aliases=True)``; important for some
  special system objects #302
* Fix: Tests with the newest Django, Salesforce, Python; including Python 3.11(beta)
* Fix: Extended SalesforceModel with PostgreSQL backend and Django >= 3.0 #299

A simple release draft is also prepared (the same text)