### PR TITLE
Travis jammy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # It is important to set "Limit concurrent jobs" to "1" in repository settings in Travis-CI
 language: python
-# Ubuntu 20.04 Focal Fossa (has a default Python 3.8, suported 3.5 - 3.9)
-dist: focal
+# Ubuntu 22.04 Jammy Jellyfish (has a default Python 3.10, suported 3.7 - 3.10)
+dist: jammy
 if: branch = main
 env:
   global:
@@ -20,10 +20,10 @@ script:
   - tox
 jobs:
   include:
-    - python: 3.6
+    - python: 3.7
       before_install:
-        - python3.6 -V
-        - python3.8 -V
-      env: TOXENV=docs_style,typing,dj20-py36,dj22-py38,dj30-py36,dj32-py38
+        - python3.7 -V
+        - python3.10 -V
+      env: TOXENV=docs_style,typing,dj41-py310,dj40-py310,dj20-py37,dj22-py37
     - python: 3.9
-      env: TOXENV=dj41-py39,dj40-py39,no_django-py39,debug_toolbar-dj32-py39
+      env: TOXENV=dj30-py39,dj32-py39,no_django-py39,debug_toolbar-dj32-py39

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ experimental.
 
 
 [4.1] 2022-08-05
------------------
+----------------
 * Add: Support for Django 4.1
 * Add: Command ``inspectdb`` can introspect actual default values
   of fields from a ``defaultValueFormula`` if it is a simple constant

--- a/tox.ini
+++ b/tox.ini
@@ -118,19 +118,3 @@ commands =
     mypy salesforce tests
     mypy salesforce/dbapi tests/test_mock tests/test_mock2 --strict
     {toxinidir}/tests/mypy.sh
-
-# === lint configurations (not tests) ===
-[flake8]
-max-line-length = 119
-exclude =
-    .git,.tox,.components,.eggs,build,migrations,models1*.py,packages_
-    tests/inspectdb/models.py
-    tests/inspectdb/dependent_model/models_template.py
-    tests/tooling/models.py
-
-[pep8]
-max-line-length = 119
-exclude=.git,.tox,.components,.eggs,build,migrations,models1*.py,packages_,tests/inspectdb/models.py,tests/tooling/models.py
-[pyflakes]
-# ignore E126 continuation line over-indented for hanging indent
-# ignore=E126

--- a/tox.ini
+++ b/tox.ini
@@ -19,10 +19,10 @@ envlist =
     debug_toolbar-dj40-py38
     # pylint-dj41-py310`
 
-# Python versions for Travis are 3.6, 3.8, 3.9 (the lowest, the default in Travis, the highest in Travis)
+# Python versions used for Travis with Jammy are 3.7, 3.8, 3.10 (default)
 # Environments tested by Travis 
-#   TOXENV=docs_style,typing,dj20-py36,dj22-py38,dj30-py36,dj32-py38
-#   TOXENV=dj40-py39,no_django-py39,debug_toolbar-dj32-py39
+#   TOXENV=docs_style,typing,dj41-py310,dj40-py310,dj20-py37,dj22-py37
+#   TOXENV=dj30-py39,dj32-py39,no_django-py39,debug_toolbar-dj32-py39
 
 [testenv]
 basepython =

--- a/tox.ini
+++ b/tox.ini
@@ -8,12 +8,12 @@
 envlist =
     docs_style
     typing
-    dj41-py310
+    dj41-py311
     dj40-py310
     dj20-py36
-    dj21-py37
-    dj22-py38
-    dj31-py39
+    dj22-py37
+    dj30-py38
+    dj32-py39
     # djdev-py311
     no_django-py38
     debug_toolbar-dj40-py38
@@ -46,8 +46,8 @@ deps =
     dj41: Django~=4.1.0   # py38-310
     djdev: https://github.com/django/django/archive/main.zip
     # local copy of django/origin main
-    # wget https://github.com/django/django/archive/main.zip -O django-40-dev.zip
-    # djdevlocal: django-40-dev.zip
+    # wget https://github.com/django/django/archive/main.zip -O django-42-dev.zip
+    # djdevlocal: django-42-dev.zip
     pylint: pylint~=2.8.0    # fixed version to not report too much
     pylint: pylint-django<2.5
     debug_toolbar: django-debug-toolbar
@@ -68,23 +68,25 @@ setenv =
     QUIET_KNOWN_BUGS={env:QUIET_KNOWN_BUGS:on}
 passenv = SLOW_TESTS
 
-# These other environments are tested by `tox -e ALL`:
-# (Especially useful is to add highest contra lowest Django combinations)
-[testenv:djdev-py310]
+# These other environments would be tested by `tox -e ALL`, but it is too much.
+[testenv:djdev-py311]
 
 [testenv:clean]
 basepython = python3
 commands =
     {envpython} manage.py test tests.clean_test_data
 
-[testenv:debug_toolbar-dj{20,32,40}-py{36,38,39}]
+[testenv:debug_toolbar-dj{20-py36,32-py39,41-py311}]
 commands = {envpython} manage.py test tests.t_debug_toolbar --settings=tests.t_debug_toolbar.settings
 
-[testenv:pylint-dj{20,21,22,30,31,32,40,41}-py{36,38,39,310}]
+[testenv:pylint-dj{20-py37,22-py37,30-py39,32-py39,40-py310,41-py310}]
+# Python 3.11 will require "wrapt>=1.14.1" and therefore to allow a newer pylint
+# New pylint requires Python >= 3.7 and has a different configuration.
+# Therefore we don't test with Python 3.6 by pylint
 setenv = DJANGO_SETTINGS_MODULE=salesforce.testrunner.settings
 commands = pylint --reports=no salesforce
 
-[testenv:no_django-py{36,38,39}]
+[testenv:no_django-py{36,311}]
 usedevelop=True
 allowlist_externals = rm
 commands =
@@ -101,7 +103,7 @@ deps =
     rstcheck
 commands =
     flake8
-    rstcheck README.rst CHANGELOG.rst
+    rstcheck --recursive README.rst CHANGELOG.rst docs
 
 [testenv:typing]
 # any python >= 3.5.3, < 3.9


### PR DESCRIPTION
* Python 3.6 is after end of life. A new Ubuntu 22.04 LTS Jammy Jellyfish is an option on Travis.
* I test frequently also with Python 3.11 beta in tox locally.