### PR TITLE
Prepare version 5.0.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
         SF_PASSWORD: ${{ secrets.SF_PASSWORD }}
         SF_HOST: ${{ secrets.SF_HOST }}
 
-        TOXENV_38:  "docs_style,typing,clean,dj22-py38,dj20-py38"
+        TOXENV_38:  "docs_style,typing,clean,dj22-py38,dj21-py38"
         TOXENV_312: "dj50-py312"
         TOXENV_311: "dj42-py311"
         TOXENV_310: "dj40-py310"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ experimental.
 [5.0.2] not released yet
 ------------------------
 * Change: Removed the old Python 3.7
+* Change: Removed the code for Django 2.0
+* Fixed many bugs in the query compiler in edge cases:...
+* Add: The query compiler is much more precise. Most of unsupported queries will
+  write a warning before they are incorrectly compiled.
+  No regression is known that a previously correct query would write a warning.
 * Add: Support for date and datetime lookup by year, quarter, month, day, week_day, hour
   e.g. group this year by month:
   .filter(date__year=2024).value('date__month').annotate(total=Sum('amount'))

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,9 +15,15 @@ experimental.
 
 [5.0.2] not released yet
 ------------------------
-* Fix: Compile correctly: .filter(related_model__field__in=...)
+* Change: Removed the old Python 3.7
+* Add: Support for date and datetime lookup by year, quarter, month, day, week_day, hour
+  e.g. group this year by month:
+  .filter(date__year=2024).value('date__month').annotate(total=Sum('amount'))
+* Add: The method .sf(minimal_aliases=True) is not necessary
+  for ContentDocumentLink .filter(...); #259
+* Fix: Compile correctly: .filter(related_model__field__in=...) Fix #302
 * Fix: Prepare tests for Salesforce API 61.0 Summer '24
-* Add: Introspect fields of type Formula
+* Add: Introspect Salesforce fields of type Formula to sf_formula="..." parameter
 
 
 [5.0.1] 2024-03-04

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,13 +13,20 @@ but a new feature can be referred by a test name if not documented yet.
 Some items here can be marked as "internal": not ready enough or
 experimental.
 
+
 [5.0.2] not released yet
 ------------------------
-* Change: Removed the old Python 3.7
-* Change: Removed the code for Django 2.0
-* Fixed many bugs in the query compiler in edge cases:...
-* Add: The query compiler is much more precise. Most of unsupported queries will
-  write a warning before they are incorrectly compiled.
+The main new features are in the improved query compiler
+
+* Remove: the old Python 3.7
+* Remove: the code for Django 2.0
+* Fix: many issues in the query compiler in edge cases:
+  - fix a query with offset, but without a limit (NotImplementedError)
+  - fix a '__range' lookup on a field of custom foreign key object (SalesforceError)
+  - fix a '=null' lookup.  It worked probably always correctly, but the old implementation was different from  standard lookups. It made it impossible to distinguish it from unsupported queries
+* Add: The query compiler is now much more precise. Most of unsupported queries will
+  write a warning before they are tried compiled. This is how users have
+  discovered some functional queries in the past.
   No regression is known that a previously correct query would write a warning.
 * Add: Support for date and datetime lookup by year, quarter, month, day, week_day, hour
   e.g. group this year by month:

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ django-salesforce
 .. image:: https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue.svg
    :target: https://www.python.org/
 
-.. image:: https://img.shields.io/badge/Django-2.0%2C%202.1%2C%202.2%20%7C%203.0%2C%203.1%20%2C%203.2%20%7C%204.0%2C%204.1%2C%204.2%20%7C%205.0-blue.svg
+.. image:: https://img.shields.io/badge/Django-2.1%2C%202.2%20%7C%203.0%2C%203.1%20%2C%203.2%20%7C%204.0%2C%204.1%2C%204.2%20%7C%205.0-blue.svg
    :target: https://www.djangoproject.com/
 
 This library allows you to load, edit and query the objects in any Salesforce instance
@@ -19,7 +19,7 @@ for most uses. It works by integrating with the Django ORM, allowing access to
 the objects in your SFDC instance (Salesforce .com) as if they were in a
 traditional database.
 
-Python 3.8 to 3.12, Django 2.0 to 5.0. (Tested also with Python 3.13b1)
+Python 3.8 to 3.12, Django 2.1 to 5.0. (Tested also with Python 3.13b1)
 
 Use with Django 5.0 or 4.2(LTS) currently requires an enteprise license key DJSF_LICENSE_KEY
 until August 2024 unless you accept the AGPL license and install our otherwise identical
@@ -303,10 +303,10 @@ Backwards-incompatible changes
 
 The last most important:
 
+-  v5.0.2: Removed support for Python 3.7 and Django 2.0
+
 -  v4.2: Some new features or versions implemented after June 2023 can require a license key
    (sponsorship) or to accept the AGPL license. (AGPL is fine for exclusive open source
    contribution or for education, but impossible if you do not share all your
    source codes.)
    Removed support for Python 3.6
-
--  v4.0: Removed support for Python 3.5

--- a/coverage_run.sh
+++ b/coverage_run.sh
@@ -11,7 +11,7 @@ $COVERAGE run -a $SOURCE manage.py makemigrations
 $COVERAGE run -a $SOURCE manage.py migrate --database=default
 $COVERAGE run -a $SOURCE manage.py check --settings=tests.tooling.settings
 
-for x in dj20-py37 dj22-py38 dj31-py39 dj40-py310; do
+for x in dj21-py38 dj22-py38 dj31-py39 dj40-py310 dj50-py312; do
     echo "*** $x ***"
     .tox/${x}/bin/coverage run -a $SOURCE manage.py inspectdb --database=salesforce >/dev/null
     .tox/${x}/bin/coverage run -a $SOURCE manage.py test salesforce

--- a/salesforce/__init__.py
+++ b/salesforce/__init__.py
@@ -14,11 +14,12 @@ import logging
 # Default version of Force.com API.
 # It can be customized by settings.DATABASES['salesforce']['API_VERSION']
 API_VERSION = '60.0'  # Spring '24
+# API_VERSION = '61.0'  # Summer '24
 
 from salesforce.dbapi.exceptions import (  # NOQA pylint:disable=unused-import,useless-import-alias,wrong-import-position
     IntegrityError as IntegrityError, DatabaseError as DatabaseError, SalesforceError as SalesforceError,
 )
 
-__version__ = "5.0.1"
+__version__ = "5.0.2"
 
 log = logging.getLogger(__name__)

--- a/salesforce/backend/__init__.py
+++ b/salesforce/backend/__init__.py
@@ -32,7 +32,6 @@ import re
 
 import django
 
-DJANGO_21_PLUS = django.VERSION[:2] >= (2, 1)
 DJANGO_22_PLUS = django.VERSION[:2] >= (2, 2)
 DJANGO_30_PLUS = django.VERSION[:2] >= (3, 0)
 DJANGO_31_PLUS = django.VERSION[:2] >= (3, 1)
@@ -43,8 +42,8 @@ DJANGO_42_PLUS = django.VERSION[:2] >= (4, 2)
 DJANGO_50_PLUS = django.VERSION[:2] >= (5, 0)
 max_django = (5, 0)
 is_dev_version = django.VERSION[3:] and re.match('(alpha|beta|rc)', django.VERSION[3])
-if django.VERSION[:2] < (2, 0) or django.VERSION[:2] > max_django and not is_dev_version:
-    raise ImportError("Django version between 2.0 and 5.0 is required "
+if django.VERSION[:2] < (2, 1) or django.VERSION[:2] > max_django and not is_dev_version:
+    raise ImportError("Django version between 2.1 and 5.0 is required "
                       "for this django-salesforce.")
     # Usually three or more blocking issues can be expected by every
     # new major Django version. Strict check before support is better.

--- a/salesforce/backend/models_lookups.py
+++ b/salesforce/backend/models_lookups.py
@@ -13,11 +13,10 @@ from django.db.models import lookups
 
 class IsNull(models.lookups.IsNull):  # pylint:disable=abstract-method
     def override_as_sql(self, compiler, connection):  # pylint:disable=unused-argument
-        # it must be relabeled if used for a children rows set
-        if compiler.soql_trans is None:
-            compiler.get_from_clause()
-        sql, params = compiler.compile(self.lhs.relabeled_clone(compiler.soql_trans))
-        return ('%s %s null' % (sql, ('=' if self.rhs else '!='))), params
+        # it will be relabeled later by sf_fix_field() to prevent a problematic double relabel
+        lhs, params = self.process_lhs(compiler, connection)
+        operator = '=' if self.rhs else '!='
+        return f"{lhs} {operator} null", params
 
     setattr(models.lookups.IsNull, 'as_salesforce', override_as_sql)
 

--- a/salesforce/backend/models_lookups.py
+++ b/salesforce/backend/models_lookups.py
@@ -29,9 +29,8 @@ class Range(models.lookups.Range):  # pylint:disable=abstract-method
         assert rhs == ('%s', '%s')
         assert len(rhs_params) == 2
         params = lhs_params + [rhs_params[0]] + lhs_params + [rhs_params[1]]
-        # The symbolic parameters %s are again substituted by %s. The real
-        # parameters will be passed finally directly to CursorWrapper.execute
-        return '(%s >= %s AND %s <= %s)' % (lhs, rhs[0], lhs, rhs[1]), params
+        lhs = compiler.sf_fix_field(lhs)
+        return f'({lhs} >= %s AND {lhs} <= %s)', params
 
     setattr(models.lookups.Range, 'as_salesforce', override_as_sql)
 

--- a/salesforce/backend/operations.py
+++ b/salesforce/backend/operations.py
@@ -152,11 +152,5 @@ class DatabaseOperations(BaseDatabaseOperations):  # pylint:disable=too-many-pub
             return f"HOUR_IN_DAY(convertTimezone({sql}))", params
         raise ValueError(f"Unsupported extract type {lookup_type!r} in Salesforce")
 
-    # # This would require much more code elsewhere
-    # def datetime_cast_date_sql(self, sql, params, tzname):
-    #     return f"DAY_ONLY(convertTimezone({sql}))", params
-
-    # def datetime_trunc_sql(self, lookup_type, sql, params, tzname):
-    #     if lookup_type == 'day':
-    #         return f"DAY_ONLY(convertTimezone({sql}))", params
-    #     raise ValueError(f"Unsupported truncate type {lookup_type!r} in Salesforce")
+    def datetime_cast_date_sql(self, sql, params, tzname):
+        return f"DAY_ONLY(convertTimezone({sql}))", params

--- a/salesforce/backend/operations.py
+++ b/salesforce/backend/operations.py
@@ -22,11 +22,10 @@ Default database operations, with unquoted names.
 
 
 class DatabaseOperations(BaseDatabaseOperations):  # pylint:disable=too-many-public-methods
-    # undefined abstract methods:
-    #    datetime_cast_date_sql, datetime_cast_time_sql, date_interval_sql,
-    #    datetime_trunc_sql,
-    #    time_trunc_sql
-    #    no_limit_value,   regex_lookup
+    # undefined abstract methods:  (these methods can not be implemented by SOQL)
+    #    datetime_cast_time_sql, date_interval_sql,
+    #    datetime_trunc_sql,     time_trunc_sql,
+    #    regex_lookup
     #
     # pylint:disable=abstract-method,no-self-use,unused-argument
 
@@ -115,6 +114,9 @@ class DatabaseOperations(BaseDatabaseOperations):  # pylint:disable=too-many-pub
         # A wildcard search is better than a search of '\\%' or '\\_', see #254
         return str(x)
         # return str(x).replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
+
+    def no_limit_value(self) -> Optional[int]:
+        return None
 
     # --- implement SOQL Date Functions supported by Salesforce
     # https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_select_date_functions.htm

--- a/salesforce/testrunner/example/models.py
+++ b/salesforce/testrunner/example/models.py
@@ -480,7 +480,7 @@ class ContentVersion(models.Model):
     title = models.CharField(max_length=255)
     description = models.TextField(blank=True, null=True)
     path_on_client = models.CharField(max_length=500, sf_read_only=models.NOT_UPDATEABLE, blank=True, null=True)
-    owner_id = models.CharField(max_length=18, db_default=models.DEFAULTED_ON_CREATE, blank=True)
+    owner = models.ForeignKey(User, models.DO_NOTHING, db_default=models.DEFAULTED_ON_CREATE, blank=True)
     file_type = models.CharField(max_length=20, sf_read_only=models.READ_ONLY)
     version_data = models.TextField(blank=True, null=True)
     content_size = models.IntegerField(sf_read_only=models.READ_ONLY, blank=True, null=True)

--- a/salesforce/testrunner/example/models.py
+++ b/salesforce/testrunner/example/models.py
@@ -437,6 +437,8 @@ class Campaign(SalesforceModel):
     name = models.CharField(max_length=80)
     number_sent = models.DecimalField(max_digits=18, decimal_places=0, verbose_name='Num Sent', blank=True, null=True)
     parent = models.ForeignKey('Campaign', on_delete=models.DO_NOTHING, blank=True, null=True)
+    start_date = models.DateField(blank=True, null=True)
+    created_date = models.DateTimeField(sf_read_only=models.READ_ONLY, auto_now_add=True)
 
 
 class CampaignMember(SalesforceModel):

--- a/salesforce/testrunner/example/models.py
+++ b/salesforce/testrunner/example/models.py
@@ -448,3 +448,46 @@ class CampaignMember(SalesforceModel):
 # this model will be removed to test removing in migrations
 class DeletedObject(SalesforceModel):
     pass
+
+
+# models for work with file attachments of objects
+
+class ContentDocument(models.Model):
+    owner_id = models.CharField(max_length=18, sf_read_only=models.NOT_CREATEABLE)
+    title = models.CharField(max_length=255, sf_read_only=models.NOT_CREATEABLE)
+    latest_published_version = models.ForeignKey('ContentVersion', models.DO_NOTHING, sf_read_only=models.READ_ONLY,
+                                                 blank=True, null=True)
+    description = models.TextField(sf_read_only=models.NOT_CREATEABLE, blank=True, null=True)
+    content_size = models.IntegerField(sf_read_only=models.READ_ONLY, blank=True, null=True)
+    file_type = models.CharField(max_length=20, sf_read_only=models.READ_ONLY, blank=True, null=True)
+    file_extension = models.CharField(max_length=40, sf_read_only=models.READ_ONLY, blank=True, null=True)
+
+
+class ContentDocumentLink(models.Model):
+    linked_entity_id = models.CharField(max_length=18, sf_read_only=models.NOT_UPDATEABLE)
+    content_document = models.ForeignKey(ContentDocument, models.DO_NOTHING, sf_read_only=models.NOT_UPDATEABLE)
+    share_type = models.CharField(max_length=40, blank=True, null=True,
+                                  choices=[('V', 'Viewer'), ('C', 'Collaborator'), ('I', 'Inferred')])
+    visibility = models.CharField(max_length=40, blank=True, null=True,
+                                  choices=[('AllUsers', 'All Users'), ('InternalUsers', 'Standard Users'),
+                                           ('SharedUsers', 'Shared Users')])
+
+
+class ContentVersion(models.Model):
+    content_document = models.ForeignKey(ContentDocument, models.DO_NOTHING, sf_read_only=models.NOT_UPDATEABLE)
+    content_url = models.URLField(blank=True, null=True)
+    version_number = models.CharField(max_length=20, sf_read_only=models.READ_ONLY, blank=True, null=True)
+    title = models.CharField(max_length=255)
+    description = models.TextField(blank=True, null=True)
+    path_on_client = models.CharField(max_length=500, sf_read_only=models.NOT_UPDATEABLE, blank=True, null=True)
+    owner_id = models.CharField(max_length=18, db_default=models.DEFAULTED_ON_CREATE, blank=True)
+    file_type = models.CharField(max_length=20, sf_read_only=models.READ_ONLY)
+    version_data = models.TextField(blank=True, null=True)
+    content_size = models.IntegerField(sf_read_only=models.READ_ONLY, blank=True, null=True)
+    file_extension = models.CharField(max_length=40, sf_read_only=models.READ_ONLY, blank=True, null=True)
+    origin = models.CharField(max_length=40, sf_read_only=models.NOT_UPDATEABLE, default='C',
+                              choices=[('C', 'Content'), ('H', 'Chatter')])
+    content_location = models.CharField(max_length=40, sf_read_only=models.NOT_UPDATEABLE, default='S',
+                                        choices=[('S', 'Salesforce'), ('E', 'External'),
+                                                 ('L', 'Social Customer Service')])
+    version_data_url = models.CharField(max_length=255, sf_read_only=models.READ_ONLY, blank=True, null=True)

--- a/salesforce/testrunner/settings.py
+++ b/salesforce/testrunner/settings.py
@@ -193,6 +193,14 @@ LOGGING = {
 
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'  # not important for Salesforce, but for Django warnings
 
+# Django Debug Toolbar >= 4.4.0
+# Django changes the DEBUG setting to False when running tests.
+# By default the Django Debug Toolbar is installed because DEBUG is set to True.
+# For most cases, you need to avoid installing the toolbar when running tests.
+# If you feel this check is in error, you can set
+# `DEBUG_TOOLBAR_CONFIG['IS_RUNNING_TESTS'] = False` to bypass this check.
+DEBUG_TOOLBAR_CONFIG = {'IS_RUNNING_TESTS': False}
+
 DJSF_LICENSE_KEY = os.environ.get('DJSF_LICENSE_KEY', '')  # configure for enterprise features
 try:
     from salesforce.testrunner.local_settings import *  # noqa pylint:disable=unused-wildcard-import,wildcard-import

--- a/salesforce/tests/test_documents.py
+++ b/salesforce/tests/test_documents.py
@@ -1,0 +1,50 @@
+from base64 import b64encode
+from typing import Optional
+
+import django
+from django.test import TestCase
+from salesforce.models import SalesforceModel
+from salesforce.testrunner.example.models import Contact, ContentDocumentLink, ContentVersion, ContentDocument
+
+
+def create_content_document_link(original_filename: str, attachment_body: bytes,
+                                 related_object: SalesforceModel, owner_id: Optional[str] = None
+                                 ) -> ContentDocumentLink:
+    kwargs = {'owner_id': owner_id} if owner_id else {}
+    blob = b64encode(attachment_body).decode('ascii')
+    c_version = ContentVersion.objects.create(
+        content_location='S',  # document is where: S: in Salesforce, E: outside of Salesforce, L: on a Social Netork
+        path_on_client=original_filename,
+        origin='C',            # C: Content Origin, H: Chatter Origin
+        title=original_filename,
+        version_data=blob,
+        **kwargs
+    )
+    c_version = ContentVersion.objects.get(id=c_version.id)  # refresh fields after creation
+    c_doc_link = ContentDocumentLink.objects.create(
+        content_document=c_version.content_document,
+        linked_entity_id=related_object.pk,
+        share_type='V',         # V - Viewer permission. C - Collaborator permission. I - Inferred permission
+        visibility='AllUsers',  # AllUsers, InternalUsers, SharedUsers
+    )
+    return c_doc_link
+
+
+class Test(TestCase):
+    databases = {'salesforce'}
+
+    def test_content_version(self) -> None:
+        c_docs = ContentDocument.objects.filter(title='some file.txt')
+        c_doc_links = list(ContentDocumentLink.objects.filter(content_document__in=c_docs))
+        if c_docs and not c_doc_links:
+            for x in c_docs:
+                x.delete()
+        if not c_doc_links:
+            contact = Contact.objects.all()[0]
+            c_doc_links = [create_content_document_link('some file.txt', b'abc\n', contact)]
+
+        connection = django.db.connections['salesforce'].connection
+        rel_url = c_doc_links[0].content_document.latest_published_version.version_data
+        ret = connection.handle_api_exceptions('GET', rel_url)
+        self.assertEqual(ret.status_code, 200)
+        self.assertEqual(ret.content, b'abc\n')

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -1244,6 +1244,11 @@ class BasicSOQLRoTest(TestCase, LazyTestMixin):
         list(qs2)
         qs = Attachment.objects.filter(parent__in=Test.objects.filter(contact__last_name='Johnson'))
         list(qs)
+        # test the '__range' lookup
+        qs = Test.objects.filter(contact__name__range=('a', 'b')).values('pk').sf(minimal_aliases=True)
+        expect_sql = "SELECT Id FROM django_Test__c WHERE (Contact__r.Name >= 'a' AND Contact__r.Name <= 'b')"
+        list(qs)
+        self.assertEqual(str(qs.query), expect_sql)
 
     def test_using_none(self) -> None:
         alias = getattr(settings, 'SALESFORCE_DB_ALIAS', 'salesforce')

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -1249,6 +1249,10 @@ class BasicSOQLRoTest(TestCase, LazyTestMixin):
         alias = getattr(settings, 'SALESFORCE_DB_ALIAS', 'salesforce')
         self.assertEqual(Contact.objects.using(None)._db, alias)
 
+    def test_with_offst(self) -> None:
+        list(Contact.objects.all()[1:2])
+        list(Contact.objects.all()[2000:])
+
     @skipUnless(default_is_sf, "depends on Salesforce database.")
     def test_dynamic_fields(self) -> None:
         """Test that fields can be copied dynamically from other model"""

--- a/salesforce/tests/test_integration.py
+++ b/salesforce/tests/test_integration.py
@@ -22,7 +22,7 @@ from django.utils.crypto import get_random_string
 
 import salesforce
 from salesforce import router
-from salesforce.backend import DJANGO_21_PLUS, DJANGO_22_PLUS, DJANGO_50_PLUS
+from salesforce.backend import DJANGO_22_PLUS, DJANGO_50_PLUS
 from salesforce.backend.test_helpers import (  # noqa pylint:disable=unused-import
     expectedFailure, expectedFailureIf, skip, skipUnless, strtobool)
 from salesforce.backend.test_helpers import (
@@ -970,8 +970,7 @@ class BasicSOQLRoTest(TestCase, LazyTestMixin):
         values_list = Contact.objects.values_list('pk', 'first_name', 'last_name')[:2]
         self.assertEqual(len(values_list), 2)
         v0 = values[0]
-        # it is a list in Django 2.1, but a tuple in Django 2.0
-        self.assertEqual(list(values_list[0]), [v0['pk'], v0['first_name'], v0['last_name']])
+        self.assertEqual(values_list[0], (v0['pk'], v0['first_name'], v0['last_name']))
 
     @skipUnless(default_is_sf, "Default database should be any Salesforce.")
     def test_double_delete(self) -> None:
@@ -1282,7 +1281,6 @@ class BasicSOQLRoTest(TestCase, LazyTestMixin):
         """Test queryset with empty slice - if high/low limits equals"""
         self.assertEqual(len(Contact.objects.all()[1:1]), 0)
 
-    @skipUnless(DJANGO_21_PLUS, "Method .explain() is only in Django >= 2.1")
     @skipUnless(default_is_sf, "depends on Salesforce database.")
     def test_select_explan(self) -> None:
         """Test EXPLAIN SELECT ..."""

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ def autosetup():
         # setuptools won't auto-detect Git managed files without this
         setup_requires=[] if not with_git else ["setuptools_git >= 0.4.2"],
 
-        install_requires=['django>=2.0'] + requirements_txt,
+        install_requires=['django>=2.1'] + requirements_txt,
 
         # metadata for upload to PyPI
         author="Hynek Cernoch",

--- a/tests/clean_test_data.py
+++ b/tests/clean_test_data.py
@@ -9,7 +9,8 @@ from unittest import TestCase
 from django.db.models import Q
 from salesforce.backend.operations import BULK_BATCH_SIZE
 from salesforce.backend.query import SalesforceQuerySet
-from salesforce.testrunner.example.models import Account, Campaign, Contact, Lead, Opportunity, Product, Test
+from salesforce.testrunner.example.models import (Account, Campaign, Contact, Lead, Opportunity, Product, Test,
+                                                  ContentDocument)
 from salesforce.tests.test_integration import sf_tables
 
 
@@ -37,6 +38,7 @@ class CleanTests(TestCase):
             qs_delete(Lead.objects.filter(LastName__startswith='UnitTest')),
             qs_delete(Opportunity.objects.filter(name__in=('test op', 'Example Opportunity'))),
             qs_delete(Product.objects.filter(Name__startswith='test ')),
+            qs_delete(ContentDocument.objects.filter(title='some file.txt')),
         ]
         if 'django_Test__c' in sf_tables():
             ret.append(qs_delete(Test.objects.all()))

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,6 @@ basepython =
     pypy3: pypy3
 deps =
     # listed also a range of Python versions officially supported by Django
-    dj20: Django~=2.0.0   # py34-37
     dj21: Django~=2.1.0   # py35-37
     dj22: Django~=2.2.17  # py35-37
     dj30: Django~=3.0.11  # py36-39
@@ -86,7 +85,7 @@ commands =
 [testenv:debug_toolbar-dj{32-py39,42-py39,50-py312}]
 commands = {envpython} manage.py test tests.t_debug_toolbar --settings=tests.t_debug_toolbar.settings
 
-[testenv:pylint-dj{20-py38,22-py38,30-py39,32-py39,40-py310,41-py310,42-py310}]
+[testenv:pylint-dj{21-py38,22-py38,30-py39,32-py39,40-py310,41-py310,42-py310}]
 # Python 3.11 will require "wrapt>=1.14.1" and therefore Python between 3.8 and 3.10 is used with pylint
 setenv = DJANGO_SETTINGS_MODULE=salesforce.testrunner.settings
 commands = pylint --reports=no salesforce

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ envlist =
     dj32-py39
     dj30-py38
     dj22-py38
-    dj20-py38
+    dj21-py38
     # djdev-py313
     no_django-py311
     debug_toolbar-dj50-py312


### PR DESCRIPTION
The main new features are in the **improved query compiler**

* Remove: the old Python 3.7
* Remove: the code for Django 2.0
* Fix: many issues in the query compiler in edge cases:
  - fix a query with offset, but without a limit (NotImplementedError)
  - fix a '__range' lookup on a field of custom foreign key object (SalesforceError)
  - fix a '=null' lookup.  It worked probably always correctly, but the old implementation was different from  standard lookups. It made it impossible to distinguish it from unsupported queries
* Add: The query compiler is now much more precise. Most of unsupported queries will
  write a warning before they are tried compiled. This is how users have
  discovered some functional queries in the past.
  No regression is known that a previously correct query would write a warning.
* Add: Support for date and datetime lookup by year, quarter, month, day, week_day, hour
  e.g. group this year by month:
       .filter(date__year=2024).value('date__month').annotate(total=Sum('amount'))
* Add: The method .sf(minimal_aliases=True) is not necessary
  for ContentDocumentLink .filter(...); #259
* Add: Introspect Salesforce fields of type Formula to sf_formula="..." parameter
* Fix: Compile correctly: .filter(related_model__field__in=...) Fix #302
* Fix: Prepared tests for Salesforce API 61.0 Summer '24