### PR TITLE
Limit package compatibility to what the package actually supports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ def autosetup():
         # setuptools won't auto-detect Git managed files without this
         setup_requires=[] if not with_git else ["setuptools_git >= 0.4.2"],
 
-        install_requires=['django>=2.1'] + requirements_txt,
+        install_requires=['django>=2.1,<5.1'] + requirements_txt,
 
         # metadata for upload to PyPI
         author="Hynek Cernoch",


### PR DESCRIPTION
This will prevent pip (and similar tools) from allowing to upgrade `Django` to `5.1` as long as `django-salesforce` does not support it.  
So far, this ended in a runtime issue which might break things.

Fixes #338 