### PR TITLE
Support Django 5.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,8 +42,8 @@ jobs:
         SF_HOST: ${{ secrets.SF_HOST }}
 
         TOXENV_38:  "docs_style,typing,clean,dj22-py38,dj21-py38"
-        TOXENV_312: "dj50-py312"
-        TOXENV_311: "dj42-py311"
+        TOXENV_312: "dj51-py312"
+        TOXENV_311: "dj50-py311,dj42-py311"
         TOXENV_310: "dj40-py310"
         TOXENV_39:  "no_django-py39,debug_toolbar-dj42-py39,dj32-py39,dj30-py39"
       run: |

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,10 +13,11 @@ but a new feature can be referred by a test name if not documented yet.
 Some items here can be marked as "internal": not ready enough or
 experimental.
 
-[...] Unpublished
------------------
+[5.1] 2024-08-31 ?
+------------------
 * The cursor rollback() method only reports a message that rollback does nothing only
   if settings.DATABASES['salesforce']['OPTIONS']['WARNING_ON_ROLLBACK'] == True
+
 
 [5.0.2] 2024-05-27
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ but a new feature can be referred by a test name if not documented yet.
 Some items here can be marked as "internal": not ready enough or
 experimental.
 
+[...] Unpublished
+-----------------
+* The cursor rollback() method only reports a message that rollback does nothing only
+  if settings.DATABASES['salesforce']['OPTIONS']['WARNING_ON_ROLLBACK'] == True
 
 [5.0.2] 2024-05-27
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -19,13 +19,13 @@ for most uses. It works by integrating with the Django ORM, allowing access to
 the objects in your SFDC instance (Salesforce .com) as if they were in a
 traditional database.
 
-Python 3.8 to 3.12, Django 2.1 to 5.0. (Tested also with Python 3.13b1)
+Python 3.8 to 3.12, Django 2.1 to 5.1. (Tested also with Python 3.13b1)
 
-Use with Django 5.0 or 4.2(LTS) currently requires an enteprise license key DJSF_LICENSE_KEY
-until August 2024 unless you accept the AGPL license and install our otherwise identical
+Use with Django 5.1 or 4.2(LTS) requires currently an enteprise license key
+DJSF_LICENSE_KEY unless you accept the AGPL license and install our otherwise identical
 package "django-salesforce-agpl" instead. The license keys are available to sponsors.
-Both versions will be unlocked automatically in Django-salesforce 5.1 when a key will be
-required for Django 5.1. Use with pre-release Django versions is free.
+Both versions will be unlocked automatically in Django-salesforce 5.2 when a key will be
+required for Django 5.2. Use with pre-release Django versions is free.
 
 
 Quick Start

--- a/salesforce/__init__.py
+++ b/salesforce/__init__.py
@@ -19,6 +19,6 @@ from salesforce.dbapi.exceptions import (  # NOQA pylint:disable=unused-import,u
     IntegrityError as IntegrityError, DatabaseError as DatabaseError, SalesforceError as SalesforceError,
 )
 
-__version__ = "5.0.2"
+__version__ = "5.1"
 
 log = logging.getLogger(__name__)

--- a/salesforce/backend/__init__.py
+++ b/salesforce/backend/__init__.py
@@ -40,10 +40,11 @@ DJANGO_40_PLUS = django.VERSION[:2] >= (4, 0)
 DJANGO_41_PLUS = django.VERSION[:2] >= (4, 1)
 DJANGO_42_PLUS = django.VERSION[:2] >= (4, 2)
 DJANGO_50_PLUS = django.VERSION[:2] >= (5, 0)
-max_django = (5, 0)
+DJANGO_51_PLUS = django.VERSION[:2] >= (5, 1)
+max_django = (5, 1)
 is_dev_version = django.VERSION[3:] and re.match('(alpha|beta|rc)', django.VERSION[3])
 if django.VERSION[:2] < (2, 1) or django.VERSION[:2] > max_django and not is_dev_version:
-    raise ImportError("Django version between 2.1 and 5.0 is required "
+    raise ImportError("Django version between 2.1 and 5.1 is required "
                       "for this django-salesforce.")
     # Usually three or more blocking issues can be expected by every
     # new major Django version. Strict check before support is better.

--- a/salesforce/backend/query.py
+++ b/salesforce/backend/query.py
@@ -200,7 +200,7 @@ def bulk_update_small(objs: 'typing.Collection[models.Model]', fields: Iterable[
     for item in objs:
         query = django.db.models.sql.subqueries.UpdateQuery(item._meta.model)  # fake query
         query.add_update_values({field: getattr(item, field) for field in fields})
-        values = salesforce.backend.utils.extract_values(query)
+        values = salesforce.backend.utils.extract_update_values(query)
         values['id'] = item.pk
         values['type_'] = item._meta.db_table
         records.append(values)

--- a/salesforce/backend/test_helpers.py
+++ b/salesforce/backend/test_helpers.py
@@ -3,7 +3,7 @@ Common helpers for tests, like test decorators
 """
 import sys
 import uuid
-from unittest import skip, skipUnless, expectedFailure, TestCase  # NOQA pylint:disable=unused-import
+from unittest import skip as skip, skipUnless as skipUnless, expectedFailure as expectedFailure, TestCase  # NOQA pylint:disable=unused-import
 from typing import Union
 
 import django
@@ -11,7 +11,8 @@ from django.conf import settings
 
 from salesforce import router
 from salesforce.dbapi.test_helpers import (  # NOQA pylint:disable=unused-import
-    LazyTestMixin, expectedFailureIf, QuietSalesforceErrors)
+    LazyTestMixin as LazyTestMixin, expectedFailureIf as expectedFailureIf,
+    QuietSalesforceErrors as QuietSalesforceErrors)
 
 # uid strings for tests that accidentally run concurrent
 uid_random = '-' + str(uuid.uuid4())[:7]

--- a/salesforce/backend/utils.py
+++ b/salesforce/backend/utils.py
@@ -352,7 +352,6 @@ class CursorWrapper:
             return self.execute_tooling_update(query)
         table = query.model._meta.db_table
         post_data = extract_values(query)
-        self.our_fix_default(post_data)  # probably not necessary
         pks = self.get_pks_from_query(query)
         log.debug('UPDATE %s(%s)%r', table, pks, post_data)
         if not pks:

--- a/salesforce/dbapi/__init__.py
+++ b/salesforce/dbapi/__init__.py
@@ -9,10 +9,10 @@ SQL commands INSERT, UPDATE and DELETE could be implemented easily, but it is no
 important because the current object implementation in Django is good enough.
 
 Purpose:
-Splitting Django-Salesforce to a high level part that depends on Django
+Django-Salesforce is splitted to a high level part that depends on Django
 (especially on a Django version) and a low level part that depends
-on Salesforce (but not on Django) has to be better for development,
-maintenance and testing.
+on Salesforce API, but not on Django.
+It is better for development, maintenance and testing.
 
 This module can run without Django installed, but Django is still main purpose.
 Configuration parameters are passed by `settings_dict` the same way as in Django.
@@ -99,6 +99,7 @@ from salesforce.dbapi.driver import (  # noqa pylint:disable=useless-import-alia
 )
 from salesforce.dbapi.exceptions import (  # noqa pylint:disable=useless-import-alias
     IntegrityError as IntegrityError, DatabaseError as DatabaseError, SalesforceError as SalesforceError,
+    OperationalError as OperationalError,
 )
 
 log = logging.getLogger(__name__)

--- a/salesforce/dbapi/driver.py
+++ b/salesforce/dbapi/driver.py
@@ -135,7 +135,8 @@ class RawConnection:
         pass
 
     def rollback(self) -> None:  # pylint:disable=no-self-use
-        log.info("Rollback is not implemented in Salesforce.")
+        if self.settings_dict.get('OPTIONS', {}).get('WARNING_ON_ROLLBACK', False):
+            log.info("Rollback is not implemented in Salesforce.")
 
     @overload
     def cursor(self) -> 'Cursor[Tuple[Any, ...]]': ...
@@ -513,7 +514,7 @@ class Cursor(Generic[_TRow]):
     for complete rows, one by one.
     """
 
-    # pylint:disable=too-many-instance-attributes
+    # pylint:disable=too-many-instance-attributes,too-many-public-methods
     def __init__(self, connection: Connection, row_type: Optional[Type[_TRow]] = None) -> None:
         # DB API attributes (public, ordered by documentation PEP 249)
         self.description = None           # type: Optional[List[Tuple[Any, ...]]]
@@ -620,6 +621,12 @@ class Cursor(Generic[_TRow]):
 
     def __next__(self) -> _TRow:
         return self._iter.__next__()
+
+    def commit(self) -> None:
+        self._connection.commit()
+
+    def rollback(self) -> None:
+        self._connection.rollback()
 
     # -- private methods
 

--- a/salesforce/dbapi/driver.py
+++ b/salesforce/dbapi/driver.py
@@ -24,10 +24,11 @@ from salesforce.auth import SalesforceAuth
 from salesforce.dbapi.common import get_max_retries, get_thread_connections, time_statistics as time_statistics
 from salesforce.dbapi.common import settings  # i.e. django.conf.settings
 from salesforce.dbapi.exceptions import (  # NOQA pylint: disable=unused-import
-    Error, InterfaceError as InterfaceError, DatabaseError as DatabaseError, DataError, OperationalError,
-    IntegrityError, InternalError, ProgrammingError, NotSupportedError, SalesforceError as SalesforceError,
-    SalesforceWarning, warn_sf,
-    FakeReq, FakeResp, GenResponse)
+    Error as Error, InterfaceError as InterfaceError, DatabaseError as DatabaseError, DataError as DataError,
+    OperationalError as OperationalError, IntegrityError as IntegrityError, InternalError as InternalError,
+    ProgrammingError as ProgrammingError, NotSupportedError as NotSupportedError,
+    SalesforceError as SalesforceError, SalesforceWarning as SalesforceWarning,
+    warn_sf, FakeReq, FakeResp, GenResponse)
 from salesforce.dbapi.subselect import QQuery, _TRow
 
 try:

--- a/salesforce/models.py
+++ b/salesforce/models.py
@@ -28,7 +28,8 @@ from django.db.models import PROTECT, DO_NOTHING  # NOQA pylint:disable=unused-w
 from salesforce.defaults import DefaultedOnCreate, DEFAULTED_ON_CREATE
 from salesforce.fields import (
     SalesforceAutoField as SalesforceAutoField, SF_PK, SfField, ForeignKey as ForeignKey)
-from salesforce.fields import NOT_UPDATEABLE, NOT_CREATEABLE, READ_ONLY
+from salesforce.fields import (NOT_UPDATEABLE as NOT_UPDATEABLE, NOT_CREATEABLE as NOT_CREATEABLE,
+                               READ_ONLY as READ_ONLY)
 from salesforce.fields import (  # noqa pylint:disable=useless-import-alias  # for other modules, but unused here
     AutoField as AutoField, BigIntegerField as BigIntegerField, BooleanField as BooleanField,
     CharField as CharField, DateField as DateField, DateTimeField as DateTimeField,

--- a/salesforce/models_template.py
+++ b/salesforce/models_template.py
@@ -21,6 +21,10 @@ Dynamic Models created by selection from
 
 
 """
+from salesforce.models import (  # NOQA pylint:disable=unused-import
+        NOT_UPDATEABLE as NOT_UPDATEABLE, NOT_CREATEABLE as NOT_CREATEABLE,
+        READ_ONLY as READ_ONLY, DO_NOTHING as DO_NOTHING,
+)
 from salesforce.models import *  # NOQA pylint:disable=unused-wildcard-import,wildcard-import
 from salesforce.backend.indep import LazyField
 import salesforce

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@
 envlist =
     docs_style
     typing
+    dj51-py312
     # dj50-py313
     dj50-py312
     dj42-py312
@@ -45,6 +46,7 @@ deps =
     dj41: Django~=4.1.0   # py38-310
     dj42: Django~=4.2.0   # py38-311
     dj50: Django~=5.0.0   # py310-312
+    dj51: Django~=5.1.0   # py310-312
     djdev: https://github.com/django/django/archive/main.zip
     # local copy of django/origin main
     # wget https://github.com/django/django/archive/main.zip -O django-42-dev.zip


### PR DESCRIPTION
A release for Django 5.1

A new Django frequently uses rollback in tests. The message about ignored rollback was annoying in a test log. It will be now silent, but can be reported if
`settings.DATABASES['salesforce']['OPTIONS']['WARNING_ON_ROLLBACK'] == True`