### PR TITLE
Django 6.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,9 +20,9 @@ jobs:
         python-version: [3.8, 3.12, 3.11, "3.10", 3.9]
     timeout-minutes: 20
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies, Customize local_settings

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
         SF_HOST: ${{ secrets.SF_HOST }}
 
         TOXENV_38:  "docs_style,typing,clean"
-        TOXENV_312: "dj52-py312,dj51-py312"
+        TOXENV_312: "dj60-py312,dj52-py312,dj51-py312"
         TOXENV_311: "dj50-py311,dj42-py311"
         TOXENV_310: "dj40-py310,dj32-py310"
         TOXENV_39:  "no_django-py39,debug_toolbar-dj42-py39"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,8 +14,18 @@ Some items here can be marked as "internal": not ready enough or
 experimental.
 
 
-[5.2] Unpublished
+[6.0] Unpublished
 -----------------
+* Add: Support for Django 6.0
+* Add: implement v.6.0 variants of new Django Database backend API functions
+* Add: Authentication by "client_credentials" flow with
+  salesforce.auth.SalesforceClientCredentialsAuth #344
+* Remove: code for the old Django 2.2 - 3.1
+* Update: Salesforce API 66.0 Spring '26
+
+
+[5.2] 2025-04-11
+----------------
 * Remove: the old Python 3.8 code
 * Remove: the old Django 2.1 code
 * Fix: queryset with Django 5.2

--- a/README.rst
+++ b/README.rst
@@ -21,13 +21,13 @@ traditional database.
 
 Python 3.9 to 3.14, Django 3.2 to 6.0.
 
-Use with Django 5.2(LTS) requires currently an enteprise license key
+Use with Django 6.0 or with LTS >= 5.2.15 requires currently an enteprise license key
 DJSF_LICENSE_KEY unless you accept the AGPL license and install our otherwise identical
 package "django-salesforce-agpl" instead. The license keys are available to sponsors.
 Use with a pre-release Django version is free.
 
-.. The version 5.2 < 5.2.15 will be free automatically in Django-salesforce 6.0 when a key will be
-.. required for Django 6.0. Use with pre-release Django versions is free. see more in the wiki
+.. The LTS Django versions >= 5.2.15 will be free automatically in Django-salesforce 6.2 when a key will be
+.. required for Django 6.2. Use with pre-release Django versions is free. see more in the wiki
 
 
 Quick Start

--- a/README.rst
+++ b/README.rst
@@ -7,10 +7,10 @@ django-salesforce
 .. image:: https://badge.fury.io/py/django-salesforce.svg
    :target: https://pypi.python.org/pypi/django-salesforce
 
-.. image:: https://img.shields.io/badge/python-3.9%20%7C%203.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue.svg
+.. image:: https://img.shields.io/badge/python-3.9%20%7C%203.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue.svg
    :target: https://www.python.org/
 
-.. image:: https://img.shields.io/badge/Django-3.2%20%7C%204.0%2C%204.1%2C%204.2%20%7C%205.0%2C%205.1%2C%205.2-blue.svg
+.. image:: https://img.shields.io/badge/Django-3.2%20%7C%204.0%2C%204.1%2C%204.2%20%7C%205.0%2C%205.1%2C%205.2%20%7C%206.0-blue.svg
    :target: https://www.djangoproject.com/
 
 This library allows you to load, edit and query the objects in any Salesforce instance
@@ -19,7 +19,7 @@ for most uses. It works by integrating with the Django ORM, allowing access to
 the objects in your SFDC instance (Salesforce .com) as if they were in a
 traditional database.
 
-Python 3.9 to 3.13, Django 3.2 to 5.2.
+Python 3.9 to 3.14, Django 3.2 to 6.0.
 
 Use with Django 5.2(LTS) requires currently an enteprise license key
 DJSF_LICENSE_KEY unless you accept the AGPL license and install our otherwise identical
@@ -27,7 +27,7 @@ package "django-salesforce-agpl" instead. The license keys are available to spon
 Use with a pre-release Django version is free.
 
 .. The version 5.2 < 5.2.15 will be free automatically in Django-salesforce 6.0 when a key will be
-.. required for Django 6.0. Use with pre-release Django versions is free. see more in wiki
+.. required for Django 6.0. Use with pre-release Django versions is free. see more in the wiki
 
 
 Quick Start

--- a/salesforce/__init__.py
+++ b/salesforce/__init__.py
@@ -13,13 +13,12 @@ import logging
 
 # Default version of Force.com API.
 # It can be customized by settings.DATABASES['salesforce']['API_VERSION']
-API_VERSION = '65.0'  # Winter '26
-# API_VERSION = '66.0'  # Spring '26  (enable after Feb 20, 2026)
+API_VERSION = '66.0'  # Spring '26  (enable after Feb 20, 2026)
 
 from salesforce.dbapi.exceptions import (  # NOQA pylint:disable=unused-import,useless-import-alias,wrong-import-position
     IntegrityError as IntegrityError, DatabaseError as DatabaseError, SalesforceError as SalesforceError,
 )
 
-__version__ = "5.2"
+__version__ = "6.0"
 
 log = logging.getLogger(__name__)

--- a/salesforce/backend/__init__.py
+++ b/salesforce/backend/__init__.py
@@ -39,10 +39,10 @@ DJANGO_50_PLUS = django.VERSION[:2] >= (5, 0)
 DJANGO_51_PLUS = django.VERSION[:2] >= (5, 1)
 DJANGO_52_PLUS = django.VERSION[:2] >= (5, 2)
 DJANGO_60_PLUS = django.VERSION[:2] >= (6, 0)
-max_django = (5, 2)
+max_django = (6, 0)
 is_dev_version = bool(django.VERSION[3:] and re.match('(alpha|beta|rc)', django.VERSION[3]))
 if django.VERSION[:2] < (3, 2) or django.VERSION[:2] > max_django and not is_dev_version:
-    raise ImportError("Django version between 3.2 and 5.2 is required "
+    raise ImportError("Django version between 3.2 and 6.0 is required "
                       "for this django-salesforce.")
     # Usually three or more blocking issues can be expected by every
     # new major Django version. Strict check before support is better.

--- a/salesforce/backend/enterprise.py
+++ b/salesforce/backend/enterprise.py
@@ -57,7 +57,7 @@ def check_enterprise_license(  # pylint:disable=too-many-locals
     z = (z >> (8 * (2 + (z & 1 << 23 == 0)))) & 0x7fff
     if g != level or level > 3 or d:
         raise LicenseError("The enterprise license key is invalid")
-    if (484896 if (lts and level <= 1) else 484896) & 1 << z:
+    if (2615072 if (lts and level <= 1) else 2615072) & 1 << z:
         raise LicenseError("This license key did not carry over to new packackage versions "
                            "after sponsorship ended.")
 
@@ -71,7 +71,7 @@ def check_license_in_latest_django() -> None:
     # and all versions of Django 5.2 will be free in Django-salesforce 6.2
     last_django = django.VERSION[:2] == max_django
     protected_lts = (django.VERSION[1] == 2 and django.VERSION[0] == max_django[0] - 1 and
-                     (max_django[1] == 1 or max_django[1] == 0 and django.VERSION[2:3] >= [15]))
+                     (max_django[1] == 1 or max_django[1] == 0 and django.VERSION[2:3] >= (15,)))
     is_dev_version = django.VERSION[3:] and re.match('(alpha|beta|rc)', django.VERSION[3])
     if (last_django or protected_lts) and not is_dev_version:
         check_enterprise_license(

--- a/salesforce/backend/enterprise.py
+++ b/salesforce/backend/enterprise.py
@@ -67,8 +67,9 @@ def check_license_in_latest_django() -> None:
     #   https://github.com/django-salesforce/django-salesforce/wiki/Release-cycle-and-Licenses
     # Django 5.0 is free in Django-salesforce >= 5.1
     # Django 5.1 is free in Django-salesforce >= 5.2
-    # Django 5.2 LTS < 5.2.15 will free with Django-salesforce 6.0
-    # and all versions of Django 5.2 will be free in Django-salesforce 6.2
+    # Django 5.2 LTS < 5.2.15 is free with Django-salesforce 6.0
+    # Django 6.0 will be free in Django-salesforce >= 6.1
+    # All versions of Django 5.2 will be free in Django-salesforce 6.2
     last_django = django.VERSION[:2] == max_django
     protected_lts = (django.VERSION[1] == 2 and django.VERSION[0] == max_django[0] - 1 and
                      (max_django[1] == 1 or max_django[1] == 0 and django.VERSION[2:3] >= (15,)))

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 sf_development = os.path.isfile('.djsf_development')
 setuptools.setup(
     install_requires=[
-        'django>=2.2' + (',<6.0' if not sf_development else ''),
+        'django>=2.2' + (',<6.1' if not sf_development else ''),
         'pytz>=2012c',
         'requests>=2.32.0',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,8 @@
 envlist =
     docs_style
     typing
-    dj52-py313
+    dj60-py314
+    dj52-py314
     dj51-py313
     dj50-py312
     dj42-py312
@@ -40,8 +41,8 @@ deps =
     dj42: Django~=4.2.0   # py38-311-312  (3.12 for Django>=4.2.8)
     dj50: Django~=5.0.0   # py310-312
     dj51: Django~=5.1.0   # py310-312     (3.13 for Django>=5.1.3)
-    dj52: Django~=5.2.0   # py310-313
-    dj60: Django~=6.0b1   # py312-314
+    dj52: Django~=5.2.0   # py310-314
+    dj60: Django~=6.0.0   # py312-314
     djdev: https://github.com/django/django/archive/main.zip
     # local copy of django/origin main
     # wget https://github.com/django/django/archive/main.zip -O django-42-dev.zip


### PR DESCRIPTION
Prepared version 6.0.  ~~Changelog and Readme edit is still necessary.~~

* Add: Support for Django 6.0
* Add: implement v.6.0 variants of new Django Database backend API functions
* Add: Authentication by "client_credentials" flow with salesforce.auth.SalesforceClientCredentialsAuth #344
* Remove: code for the old Django 2.2 - 3.1
* Update: Salesforce API 66.0 Spring '26